### PR TITLE
ポケモン画像と名前の一覧画像を表示するための通信周りの実装とUIの改善

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
+    id 'org.jetbrains.kotlin.plugin.serialization' version '1.7.10'
 }
 
 android {
@@ -67,4 +68,15 @@ dependencies {
     androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
     debugImplementation 'androidx.compose.ui:ui-tooling'
     debugImplementation 'androidx.compose.ui:ui-test-manifest'
+
+    // Retrofit
+    implementation "com.squareup.retrofit2:retrofit:2.9.0"
+    // Retrofit with Kotlin serialization Converter
+    implementation "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:0.8.0"
+    // logger
+    implementation 'com.squareup.okhttp3:logging-interceptor:3.8.0'
+    // Kotlin serialization
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.0"
+
+    implementation "androidx.lifecycle:lifecycle-runtime-compose:2.6.0-alpha1"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.8.0'
     implementation platform('org.jetbrains.kotlin:kotlin-bom:1.8.0')
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
+    implementation "androidx.lifecycle:lifecycle-runtime-compose:2.6.0-alpha1"
     implementation 'androidx.activity:activity-compose:1.5.1'
     implementation platform('androidx.compose:compose-bom:2022.10.00')
     implementation 'androidx.compose.ui:ui'
@@ -77,6 +78,6 @@ dependencies {
     implementation 'com.squareup.okhttp3:logging-interceptor:3.8.0'
     // Kotlin serialization
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.0"
-
-    implementation "androidx.lifecycle:lifecycle-runtime-compose:2.6.0-alpha1"
+    // coil
+    implementation "io.coil-kt:coil-compose:2.1.0"
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/example/pokebook/model/Pokemon.kt
+++ b/app/src/main/java/com/example/pokebook/model/Pokemon.kt
@@ -27,30 +27,7 @@ data class PokemonListItem(
  */
 @Serializable
 data class PokemonPersonalData(
-//    val abilities: List<Ability>,
-//    @SerialName("base_experience")
-//    val baseExperience: Int,
-//    val forms: List<Form>,
-//    @SerialName("game_indices")
-//    val gameIndices: List<GameIndex>,
-//    val height: Int,
-//    @SerialName("held_items")
-//    val heldItems: List<Object>,
-//    val id: Int,
-//    @SerialName("is_default")
-//    val isDefault: Boolean,
-//    @SerialName("location_area_encounters")
-//    val areaEncounters: String,
-//    val moves: List<Moves>,
-//    val name: String,
-//    val order: Int,
-//    @SerialName("past_types")
-//    val pastTypes: List<Object>,
-//    val species: Species,
     val sprites: Sprites,
-//    val stats: List<Stats>,
-//    val types: List<Type>,
-//    val weight:Int
 )
 @Serializable
 data class Sprites(

--- a/app/src/main/java/com/example/pokebook/model/Pokemon.kt
+++ b/app/src/main/java/com/example/pokebook/model/Pokemon.kt
@@ -1,9 +1,75 @@
 package com.example.pokebook.model
 
 import androidx.annotation.DrawableRes
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
-sealed interface Pokemon
+@Serializable
+data class Pokemon(
+    val count: Int,
+    val next: String,
+    val previous: String? = null,
+    val results: List<PokemonListItem>
+)
 
+/**
+ * ポケモン一覧取得
+ */
+@Serializable
+data class PokemonListItem(
+    val name: String = "",
+    val url: String = ""
+)
+
+
+/**
+ * ポケモン個体の情報
+ */
+@Serializable
+data class PokemonPersonalData(
+//    val abilities: List<Ability>,
+//    @SerialName("base_experience")
+//    val baseExperience: Int,
+//    val forms: List<Form>,
+//    @SerialName("game_indices")
+//    val gameIndices: List<GameIndex>,
+//    val height: Int,
+//    @SerialName("held_items")
+//    val heldItems: List<Object>,
+//    val id: Int,
+//    @SerialName("is_default")
+//    val isDefault: Boolean,
+//    @SerialName("location_area_encounters")
+//    val areaEncounters: String,
+//    val moves: List<Moves>,
+//    val name: String,
+//    val order: Int,
+//    @SerialName("past_types")
+//    val pastTypes: List<Object>,
+//    val species: Species,
+    val sprites: Sprites,
+//    val stats: List<Stats>,
+//    val types: List<Type>,
+//    val weight:Int
+)
+@Serializable
+data class Sprites(
+    val other: Other
+)
+
+@Serializable
+data class Other(
+    @SerialName("official-artwork")
+    val officialArtwork:OfficialArtwork
+)
+
+@Serializable
+data class OfficialArtwork(
+    @SerialName("front_default")
+    val imgUrl:String
+)
+
+@Serializable
 data class Profile(
     val number: Int = 0,
     val name: String = "",
@@ -12,10 +78,11 @@ data class Profile(
     @DrawableRes val imageResourceId: Int = 0,
     val height: Int = 0,
     val weight: Int = 0
-) : Pokemon
+)
 
+@Serializable
 data class Performance(
     val hp: Int = 0,
     val attack: Int = 0,
     val defense: Int = 0
-) : Pokemon
+)

--- a/app/src/main/java/com/example/pokebook/model/Pokemon.kt
+++ b/app/src/main/java/com/example/pokebook/model/Pokemon.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class Pokemon(
     val count: Int,
-    val next: String,
+    val next: String? = null,
     val previous: String? = null,
     val results: List<PokemonListItem>
 )
@@ -20,7 +20,6 @@ data class PokemonListItem(
     val name: String = "",
     val url: String = ""
 )
-
 
 /**
  * ポケモン個体の情報

--- a/app/src/main/java/com/example/pokebook/network/PokeApiService.kt
+++ b/app/src/main/java/com/example/pokebook/network/PokeApiService.kt
@@ -1,0 +1,44 @@
+package com.example.pokebook.network
+
+import com.example.pokebook.model.Pokemon
+import com.example.pokebook.model.PokemonPersonalData
+import com.example.pokebook.network.RetrofitInstance.Companion.getRetrofitInstance
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+private const val BASE_URL = "https://pokeapi.co/api/v2/"
+
+class RetrofitInstance {
+    companion object {
+        fun getRetrofitInstance(): Retrofit {
+            val httpLogging = HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY)
+            val httpClientBuilder = OkHttpClient.Builder().addInterceptor(httpLogging)
+
+            return Retrofit.Builder()
+                .addConverterFactory(Json{ignoreUnknownKeys = true}.asConverterFactory(MediaType.get("application/json")))
+                .baseUrl(BASE_URL)
+                .client(httpClientBuilder.build())
+                .build()
+        }
+    }
+}
+
+interface PokeApiService {
+    @GET("pokemon")
+    suspend fun getPokemonList(): Pokemon
+
+    @GET("pokemon/{path}")
+    suspend fun getPokemonPersonalData(@Path("path") number: String): PokemonPersonalData
+}
+
+object PokeApi {
+    val retrofitService: PokeApiService by lazy {
+        getRetrofitInstance().create(PokeApiService::class.java)
+    }
+}

--- a/app/src/main/java/com/example/pokebook/network/PokeApiService.kt
+++ b/app/src/main/java/com/example/pokebook/network/PokeApiService.kt
@@ -6,6 +6,7 @@ import com.example.pokebook.network.RetrofitInstance.Companion.getRetrofitInstan
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -17,13 +18,9 @@ private const val BASE_URL = "https://pokeapi.co/api/v2/"
 class RetrofitInstance {
     companion object {
         fun getRetrofitInstance(): Retrofit {
-            val httpLogging = HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY)
-            val httpClientBuilder = OkHttpClient.Builder().addInterceptor(httpLogging)
-
             return Retrofit.Builder()
-                .addConverterFactory(Json{ignoreUnknownKeys = true}.asConverterFactory(MediaType.get("application/json")))
+                .addConverterFactory(Json{ignoreUnknownKeys = true}.asConverterFactory("application/json".toMediaType()))
                 .baseUrl(BASE_URL)
-                .client(httpClientBuilder.build())
                 .build()
         }
     }

--- a/app/src/main/java/com/example/pokebook/network/PokeApiService.kt
+++ b/app/src/main/java/com/example/pokebook/network/PokeApiService.kt
@@ -12,6 +12,7 @@ import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.http.GET
 import retrofit2.http.Path
+import retrofit2.http.Query
 
 private const val BASE_URL = "https://pokeapi.co/api/v2/"
 
@@ -19,7 +20,9 @@ class RetrofitInstance {
     companion object {
         fun getRetrofitInstance(): Retrofit {
             return Retrofit.Builder()
-                .addConverterFactory(Json{ignoreUnknownKeys = true}.asConverterFactory("application/json".toMediaType()))
+                .addConverterFactory(Json {
+                    ignoreUnknownKeys = true
+                }.asConverterFactory("application/json".toMediaType()))
                 .baseUrl(BASE_URL)
                 .build()
         }
@@ -27,9 +30,24 @@ class RetrofitInstance {
 }
 
 interface PokeApiService {
+    /**
+     * ポケモン一覧取得（クエリなし）
+     */
     @GET("pokemon")
     suspend fun getPokemonList(): Pokemon
 
+    /**
+     * ポケモン一覧取得（クエリあり）
+     */
+    @GET("pokemon")
+    suspend fun getPokemonList(
+        @Query("offset") offset: String,
+        @Query("limit") limit: String
+    ): Pokemon
+
+    /**
+     * ポケモン個体情報取得
+     */
     @GET("pokemon/{path}")
     suspend fun getPokemonPersonalData(@Path("path") number: String): PokemonPersonalData
 }

--- a/app/src/main/java/com/example/pokebook/repository/HomeRepository.kt
+++ b/app/src/main/java/com/example/pokebook/repository/HomeRepository.kt
@@ -1,0 +1,26 @@
+package com.example.pokebook.repository
+
+import com.example.pokebook.model.Pokemon
+import com.example.pokebook.model.PokemonPersonalData
+import com.example.pokebook.network.PokeApi
+import com.example.pokebook.network.PokeApiService
+import retrofit2.http.Path
+
+/**
+ * 一覧画面取得に関するリポジトリー
+ */
+interface HomeRepository {
+    suspend fun getPokemonList(): Pokemon
+
+    suspend fun getPokemonPersonalData(number: String): PokemonPersonalData
+}
+
+class DefaultHomeRepository() : HomeRepository {
+    override suspend fun getPokemonList(): Pokemon {
+        return PokeApi.retrofitService.getPokemonList()
+    }
+
+    override suspend fun getPokemonPersonalData(number: String): PokemonPersonalData {
+        return PokeApi.retrofitService.getPokemonPersonalData(number)
+    }
+}

--- a/app/src/main/java/com/example/pokebook/repository/HomeRepository.kt
+++ b/app/src/main/java/com/example/pokebook/repository/HomeRepository.kt
@@ -1,5 +1,6 @@
 package com.example.pokebook.repository
 
+import android.util.Log
 import com.example.pokebook.model.Pokemon
 import com.example.pokebook.model.PokemonPersonalData
 import com.example.pokebook.network.PokeApi
@@ -12,12 +13,21 @@ import retrofit2.http.Path
 interface HomeRepository {
     suspend fun getPokemonList(): Pokemon
 
+    suspend fun getPokemonList(offset: String): Pokemon
+
     suspend fun getPokemonPersonalData(number: String): PokemonPersonalData
 }
 
 class DefaultHomeRepository() : HomeRepository {
     override suspend fun getPokemonList(): Pokemon {
         return PokeApi.retrofitService.getPokemonList()
+    }
+
+    override suspend fun getPokemonList(offset: String): Pokemon {
+        return PokeApi.retrofitService.getPokemonList(
+            offset = offset,
+            limit = "20"
+        )
     }
 
     override suspend fun getPokemonPersonalData(number: String): PokemonPersonalData {

--- a/app/src/main/java/com/example/pokebook/ui/activity/MainActivity.kt
+++ b/app/src/main/java/com/example/pokebook/ui/activity/MainActivity.kt
@@ -23,10 +23,7 @@ class MainActivity : ComponentActivity() {
                     color = MaterialTheme.colorScheme.background
                 ) {
                     val homeViewModel: HomeViewModel = viewModel()
-                    HomeScreen(
-                        uiState = homeViewModel.pokeListUiState,
-//                        apiState = homeViewModel.apiState
-                    )
+                    HomeScreen(homeViewModel)
                 }
             }
         }

--- a/app/src/main/java/com/example/pokebook/ui/activity/MainActivity.kt
+++ b/app/src/main/java/com/example/pokebook/ui/activity/MainActivity.kt
@@ -6,16 +6,11 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
-import com.example.pokebook.ui.screen.ActivityScreen
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.pokebook.ui.screen.HomeScreen
-import com.example.pokebook.ui.screen.MultipleItemsBottomNavigation
 import com.example.pokebook.ui.theme.PokeBookTheme
+import com.example.pokebook.ui.viewModel.HomeViewModel
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -27,7 +22,11 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    HomeScreen()
+                    val homeViewModel: HomeViewModel = viewModel()
+                    HomeScreen(
+                        uiState = homeViewModel.pokeListUiState,
+//                        apiState = homeViewModel.apiState
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/example/pokebook/ui/screen/CommonScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/CommonScreen.kt
@@ -1,0 +1,38 @@
+package com.example.pokebook.ui.screen
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.example.pokebook.R
+
+@Composable
+fun LoadingScreen(modifier: Modifier = Modifier) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier.fillMaxSize()
+    ) {
+        Image(
+            modifier = Modifier.size(200.dp),
+            painter = painterResource(R.drawable.loading_img),
+            contentDescription = stringResource(R.string.loading)
+        )
+    }
+}
+
+@Composable
+fun ErrorScreen(modifier: Modifier = Modifier) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier.fillMaxSize()
+    ) {
+        Text(stringResource(R.string.loading_failed))
+    }
+}

--- a/app/src/main/java/com/example/pokebook/ui/screen/CommonScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/CommonScreen.kt
@@ -13,6 +13,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.example.pokebook.R
 
+/**
+ * Loading画面
+ */
 @Composable
 fun LoadingScreen(modifier: Modifier = Modifier) {
     Box(
@@ -27,6 +30,9 @@ fun LoadingScreen(modifier: Modifier = Modifier) {
     }
 }
 
+/**
+ * エラー画面
+ */
 @Composable
 fun ErrorScreen(modifier: Modifier = Modifier) {
     Box(

--- a/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
@@ -2,61 +2,72 @@ package com.example.pokebook.ui.screen
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults.cardElevation
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.pokebook.R
-import com.example.pokebook.data.PokemonDataSource
-import com.example.pokebook.model.Pokemon
-import com.example.pokebook.model.Profile
+import com.example.pokebook.model.PokemonListItem
+import com.example.pokebook.ui.viewModel.ApiState
+import com.example.pokebook.ui.viewModel.HomeViewModel
+import com.example.pokebook.ui.viewModel.PokemonUiData
+import kotlinx.coroutines.flow.StateFlow
 
 @Composable
-fun HomeScreen() {
-        PokeList(PokemonDataSource.pokemonList)
+fun HomeScreen(
+    uiState: StateFlow<List<PokemonUiData>>,
+//    apiState: ApiState,
+    modifier: Modifier = Modifier
+) {
+    val state by uiState.collectAsState(emptyList())
+    PokeList(state)
+//    when (apiState) {
+//        ApiState.Error -> ErrorScreen(modifier)
+//        ApiState.Loading -> LoadingScreen(modifier)
+//        is ApiState.Success<*> -> PokeList(state, modifier)
+//    }
 }
 
 @Composable
-private fun PokeList(pokeList:List<Profile>) {
+private fun PokeList(
+    pokeList: List<PokemonUiData>,
+    modifier: Modifier = Modifier
+) {
     LazyVerticalGrid(
         columns = GridCells.Adaptive(minSize = 150.dp)
-    ){
-        items(pokeList){ listItem ->
+    ) {
+        items(pokeList) { listItem ->
             PokeCard(listItem)
         }
     }
 }
 
 @Composable
-private fun PokeCard(pokemon: Profile, modifier: Modifier = Modifier) {
+private fun PokeCard(pokemon: PokemonUiData, modifier: Modifier = Modifier) {
     Card(modifier = modifier.padding(8.dp), elevation = cardElevation(4.dp)) {
         Box(contentAlignment = Alignment.BottomCenter) {
             Image(
                 modifier = Modifier
                     .padding(bottom = 20.dp),
-                painter = painterResource(id= pokemon.imageResourceId),
+                painter = painterResource(id = R.drawable.poke),
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
             )
@@ -79,11 +90,22 @@ private fun PokeCard(pokemon: Profile, modifier: Modifier = Modifier) {
 @Preview
 @Composable
 private fun PokeCardPreview() {
-    PokeCard(Profile( name = "pika1",imageResourceId = R.drawable.poke))
+    PokeCard(
+        PokemonUiData(name = "ピカチュウ")
+    )
 }
 
 @Preview
 @Composable
-private fun HomeScreenPreview(){
-    HomeScreen()
+private fun PokeListPreview() {
+    PokeList(
+        listOf(
+            PokemonUiData(name = "ピカチュウ"),
+            PokemonUiData(name = "ピカチュウ"),
+            PokemonUiData(name = "ピカチュウ"),
+            PokemonUiData(name = "ピカチュウ"),
+            PokemonUiData(name = "ピカチュウ"),
+            PokemonUiData(name = "ピカチュウ")
+        )
+    )
 }

--- a/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
@@ -1,6 +1,6 @@
 package com.example.pokebook.ui.screen
 
-import androidx.compose.foundation.Image
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
@@ -19,23 +19,20 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.pokebook.R
-import com.example.pokebook.model.PokemonListItem
-import com.example.pokebook.ui.viewModel.ApiState
-import com.example.pokebook.ui.viewModel.HomeViewModel
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
 import com.example.pokebook.ui.viewModel.PokemonUiData
 import kotlinx.coroutines.flow.StateFlow
 
 @Composable
 fun HomeScreen(
     uiState: StateFlow<List<PokemonUiData>>,
-//    apiState: ApiState,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    //    apiState: ApiState
 ) {
     val state by uiState.collectAsState(emptyList())
     PokeList(state)
@@ -64,12 +61,14 @@ private fun PokeList(
 private fun PokeCard(pokemon: PokemonUiData, modifier: Modifier = Modifier) {
     Card(modifier = modifier.padding(8.dp), elevation = cardElevation(4.dp)) {
         Box(contentAlignment = Alignment.BottomCenter) {
-            Image(
-                modifier = Modifier
-                    .padding(bottom = 20.dp),
-                painter = painterResource(id = R.drawable.poke),
-                contentDescription = null,
+            AsyncImage(
+                model = ImageRequest.Builder(context = LocalContext.current)
+                    .data(pokemon.imageUri).apply { Log.d("test","pokemon.imageUri:${pokemon.imageUri}") }
+                    .crossfade(true)
+                    .build(),
+                modifier = Modifier.padding(bottom = 20.dp),
                 contentScale = ContentScale.Crop,
+                contentDescription = null
             )
             Text(
                 text = pokemon.name,

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/HomeState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/HomeState.kt
@@ -1,0 +1,21 @@
+package com.example.pokebook.ui.viewModel
+
+sealed interface HomeScreenLoading
+
+/**
+ * 一覧表示に必要な情報
+ */
+data class PokemonUiData(
+    val name:String = "",
+    val url: String = "",
+    var imageUri: String = "",
+)
+
+/**
+ *  ポケモン一覧取得時の通信状態
+ */
+sealed interface ApiState {
+    data class Success<T>(val result: T) : ApiState
+    object Error : ApiState
+    object Loading : ApiState
+}

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/HomeState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/HomeState.kt
@@ -1,15 +1,45 @@
 package com.example.pokebook.ui.viewModel
 
-sealed interface HomeScreenLoading
+import java.util.UUID
+
+/**
+ * 一覧表示画面の状態に関する情報
+ */
+sealed class HomeUiState {
+    object Loading : HomeUiState()
+    data class Fetched(
+        val uiDataList: MutableList<HomeScreenUiData>
+    ) : HomeUiState()
+
+    object InitialState : HomeUiState()
+}
 
 /**
  * 一覧表示に必要な情報
  */
-data class PokemonUiData(
-    val name:String = "",
+data class HomeScreenUiData(
+    val name: String = "",
     val url: String = "",
-    var imageUri: String = "",
+    var imageUri: String = ""
 )
+
+data class HomeScreenConditionState(
+    val count: Int = 0,
+    val offset: String = "",
+    val previous: String = "",
+    val currentNumberStart: String = "1",
+)
+
+/**
+ * エラー表示に関する情報
+ */
+sealed class HomeUiEvent(
+    // ワンショットのイベントとして管理
+    val id: Long = UUID.randomUUID().mostSignificantBits
+) {
+    data class Error(val e: Throwable) : HomeUiEvent()
+}
+
 
 /**
  *  ポケモン一覧取得時の通信状態

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/HomeViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/HomeViewModel.kt
@@ -1,0 +1,79 @@
+package com.example.pokebook.ui.viewModel
+
+import android.net.Uri
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.pokebook.repository.DefaultHomeRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class HomeViewModel : ViewModel() {
+    private var _pokeListUiState: MutableStateFlow<MutableList<PokemonUiData>> =
+        MutableStateFlow(mutableListOf())
+    val pokeListUiState = _pokeListUiState.asStateFlow()
+    private val repository = DefaultHomeRepository()
+
+//    var apiState: ApiState by mutableStateOf(ApiState.Loading)
+//        private set
+
+    init {
+        getPokemonList()
+    }
+
+    /**
+     * ポケモンリスト取得
+     */
+    private fun getPokemonList() {
+        viewModelScope.launch {
+            runCatching {
+                repository.getPokemonList()
+//                PokeApi.retrofitService.getPokemonList()
+            }
+                .onSuccess {
+                    _pokeListUiState.value = it.results.map { listItem ->
+                        PokemonUiData(
+                            name = listItem.name,
+                            url = listItem.url
+                        )
+                    }.toMutableList()
+
+                    pokeListUiState.value.forEach { item ->
+                        val pokemonNumber = Uri.parse(item.url).lastPathSegment
+
+                        // ポケモンNo.が取得できたらポケモン個体情報を取得する
+                        pokemonNumber?.let { number ->
+                            getPokemonPersonalData(
+                                number = number,
+                                pokemonUiData = item
+                            )
+                        }
+                    }
+//                    apiState = ApiState.Success(it)
+                }
+                .onFailure {
+//                    apiState = ApiState.Error
+                    Log.d("error", "e[getPokemonList]:$it")
+                }
+        }
+    }
+
+    /**
+     * 個別のポケモン情報取得
+     */
+    private fun getPokemonPersonalData(number: String, pokemonUiData: PokemonUiData) {
+        viewModelScope.launch {
+            runCatching {
+                repository.getPokemonPersonalData(number)
+//                PokeApi.retrofitService.getPokemonPersonalData(number)
+            }
+                .onSuccess {
+                    pokemonUiData.imageUri = it.sprites.other.officialArtwork.imgUrl
+                }
+                .onFailure {
+                    Log.d("error", "e[getPokemonPersonalData]:$it")
+                }
+        }
+    }
+}

--- a/app/src/main/res/drawable/loading_img.xml
+++ b/app/src/main/res/drawable/loading_img.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2023 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="72"
+    android:viewportHeight="72">
+    <path
+        android:fillColor="#cccccf"
+        android:pathData="M36.06,28.92L36.06,32.18"
+        android:strokeWidth="1"
+        android:strokeColor="#e7e7e7"
+        android:strokeLineCap="round" />
+    <path
+        android:fillColor="#c8c8cc"
+        android:pathData="M39.45,29.88L37.82,32.71"
+        android:strokeWidth="1"
+        android:strokeColor="#cacaca"
+        android:strokeLineCap="round" />
+    <path
+        android:fillColor="#bbbbbe"
+        android:pathData="M42.12,32.32L39.3,33.95"
+        android:strokeWidth="1"
+        android:strokeColor="#cdcdcd"
+        android:strokeLineCap="round" />
+    <path
+        android:fillColor="#b2b2b7"
+        android:pathData="M39.8,35.98L43.06,35.98"
+        android:strokeWidth="1"
+        android:strokeColor="#cbcbcb"
+        android:strokeLineCap="round" />
+    <path
+        android:fillColor="#d0d0d4"
+        android:pathData="M32.77,29.99L34.4,32.81"
+        android:strokeWidth="1"
+        android:strokeColor="#ededed"
+        android:strokeLineCap="round" />
+    <path
+        android:fillColor="#949497"
+        android:pathData="M30.1,32.42L32.92,34.05"
+        android:strokeWidth="1"
+        android:strokeColor="#525252"
+        android:strokeLineCap="round" />
+    <path
+        android:fillColor="#97979b"
+        android:pathData="M32.42,35.98L29.16,35.98"
+        android:strokeWidth="1"
+        android:strokeColor="#6e6e6e"
+        android:strokeLineCap="round" />
+    <path
+        android:fillColor="#a8a8ac"
+        android:pathData="M36.06,43.08L36.06,39.82"
+        android:strokeWidth="1"
+        android:strokeColor="#a0a0a0"
+        android:strokeLineCap="round" />
+    <path
+        android:fillColor="#cacaca"
+        android:pathData="M39.7,41.99L38.07,39.16"
+        android:strokeWidth="1"
+        android:strokeColor="#cacaca"
+        android:strokeLineCap="round" />
+    <path
+        android:fillColor="#b6b6ba"
+        android:pathData="M42.19,39.4L39.37,37.77"
+        android:strokeWidth="1"
+        android:strokeColor="#ccc"
+        android:strokeLineCap="round" />
+    <path
+        android:fillColor="#a1a1a5"
+        android:pathData="M32.46,41.98L34.09,39.16"
+        android:strokeWidth="1"
+        android:strokeColor="#909090"
+        android:strokeLineCap="round" />
+    <path
+        android:fillColor="#9d9da0"
+        android:pathData="M29.85,39.4L32.67,37.77"
+        android:strokeWidth="1"
+        android:strokeColor="#7a7a7a"
+        android:strokeLineCap="round" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,4 +6,7 @@
     <string name="icon_setting">setting</string>
     <string name="loading">loading</string>
     <string name="loading_failed">Failed to load</string>
+    <string name="displayedNumber">No.%s - No.%s</string>
+    <string name="back_button">◀︎戻る︎</string>
+    <string name="next_button">次へ ▶︎︎</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,6 @@
     <string name="icon_search">search</string>
     <string name="icon_like">like</string>
     <string name="icon_setting">setting</string>
+    <string name="loading">loading</string>
+    <string name="loading_failed">Failed to load</string>
 </resources>


### PR DESCRIPTION
苦労したところメモ
・ポケモンの名前と画像が別のAPIで返ってくるため、一覧表示の際にAPIを２つ叩く必要があり、非同期処理の待ち合わせ等の実装で苦労した
なかなか上手くいかず、名前だけ表示されて終わったり、画像が数枚しか表示されなかったりした
→画像取得が終わるまで表示を待ち合わせる処理にasyncを使用

・戻ボタンの実装に少し手こずった
→APIの返却値のpreviousを使えば良いだけだった