### PR TITLE
ポケモン一覧から任意のポケモンを表示できるよう処理を追加

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,4 +82,5 @@ dependencies {
     implementation "io.coil-kt:coil-compose:2.1.0"
     // Navigation Compose
     implementation "androidx.navigation:navigation-compose:2.4.0-rc01"
+    implementation "androidx.lifecycle:lifecycle-runtime-compose:2.6.0-alpha1"
 }

--- a/app/src/main/java/com/example/pokebook/ui/activity/MainActivity.kt
+++ b/app/src/main/java/com/example/pokebook/ui/activity/MainActivity.kt
@@ -15,22 +15,27 @@ import com.example.pokebook.ui.screen.HomeScreen
 import com.example.pokebook.ui.screen.PokemonDetailScreen
 import com.example.pokebook.ui.theme.PokeBookTheme
 import com.example.pokebook.ui.viewModel.HomeViewModel
+import com.example.pokebook.ui.viewModel.PokemonDetailViewModel
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val homeViewModel = HomeViewModel()
+        val pokemonDetailViewModel = PokemonDetailViewModel()
+
         setContent {
             val navController = rememberNavController()
             NavHost(navController = navController, startDestination = "homeScreen") {
                 composable(route = "homeScreen") {
+
                     PokeBookTheme {
                         Surface(
                             modifier = Modifier.fillMaxSize(),
                             color = MaterialTheme.colorScheme.background
                         ) {
-                            val homeViewModel: HomeViewModel = viewModel()
                             HomeScreen(
-                                viewModel = homeViewModel,
+                                homeViewModel = homeViewModel,
+                                pokemonDetailViewModel = pokemonDetailViewModel,
                                 onClickCard = { navController.navigate("pokemonDetailScreen") }
                             )
                         }
@@ -43,22 +48,13 @@ class MainActivity : ComponentActivity() {
                             color = MaterialTheme.colorScheme.background
                         ) {
                             PokemonDetailScreen(
+                                pokemonDetailViewModel = pokemonDetailViewModel,
                                 onClickCard = { navController.navigateUp() }
                             )
                         }
                     }
                 }
             }
-//            PokeBookTheme {
-//                // A surface container using the 'background' color from the theme
-//                Surface(
-//                    modifier = Modifier.fillMaxSize(),
-//                    color = MaterialTheme.colorScheme.background
-//                ) {
-//                    val homeViewModel: HomeViewModel = viewModel()
-//                    HomeScreen(homeViewModel)
-//                }
-//            }
         }
     }
 }

--- a/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.example.pokebook.R
@@ -41,20 +42,23 @@ import com.example.pokebook.ui.viewModel.HomeScreenConditionState
 import com.example.pokebook.ui.viewModel.HomeScreenUiData
 import com.example.pokebook.ui.viewModel.HomeUiState
 import com.example.pokebook.ui.viewModel.HomeViewModel
+import com.example.pokebook.ui.viewModel.PokemonDetailViewModel
 import kotlinx.coroutines.flow.StateFlow
 
 @SuppressLint("StateFlowValueCalledInComposition")
 @Composable
 fun HomeScreen(
-    viewModel: HomeViewModel,
+    homeViewModel: HomeViewModel,
+    pokemonDetailViewModel: PokemonDetailViewModel,
     onClickCard: () -> Unit
 ) {
     HomeScreen(
-        uiState = viewModel.uiState,
-        conditionState = viewModel.conditionState,
-        onClickNext = viewModel::onClickNext,
-        onClickBack = viewModel::onClickBack,
-        onClickCard = onClickCard
+        uiState = homeViewModel.uiState,
+        conditionState = homeViewModel.conditionState,
+        onClickNext = homeViewModel::onClickNext,
+        onClickBack = homeViewModel::onClickBack,
+        onClickCard = onClickCard,
+        getPokemonDescription = pokemonDetailViewModel::getPokemonDescription
     )
 }
 
@@ -65,7 +69,8 @@ private fun HomeScreen(
     conditionState: StateFlow<HomeScreenConditionState>,
     onClickNext: () -> Unit,
     onClickBack: () -> Unit,
-    onClickCard: () -> Unit
+    onClickCard: () -> Unit,
+    getPokemonDescription: (String) -> Unit
 ) {
     val state by uiState.collectAsStateWithLifecycle()
 
@@ -77,7 +82,8 @@ private fun HomeScreen(
                 pokemonUiDataList = (state as HomeUiState.Fetched).uiDataList,
                 onClickNext = onClickNext,
                 onClickBack = onClickBack,
-                onClickCard = onClickCard
+                onClickCard = onClickCard,
+                getPokemonDescription = getPokemonDescription
             )
         }
 
@@ -93,7 +99,8 @@ private fun PokeList(
     pokemonUiDataList: List<HomeScreenUiData>,
     onClickNext: () -> Unit,
     onClickBack: () -> Unit,
-    onClickCard: () -> Unit
+    onClickCard: () -> Unit,
+    getPokemonDescription: (String) -> Unit
 ) {
     Column {
         Text(
@@ -156,7 +163,8 @@ private fun PokeList(
         }
         PokeList(
             pokemonUiDataList = pokemonUiDataList,
-            onClickCard = onClickCard
+            onClickCard = onClickCard,
+            getPokemonDescription = getPokemonDescription
         )
     }
 }
@@ -167,7 +175,8 @@ private fun PokeList(
 @Composable
 private fun PokeList(
     pokemonUiDataList: List<HomeScreenUiData>,
-    onClickCard: () -> Unit
+    onClickCard: () -> Unit,
+    getPokemonDescription: (String) -> Unit
 ) {
     LazyVerticalGrid(
         columns = GridCells.Adaptive(minSize = 150.dp),
@@ -175,7 +184,8 @@ private fun PokeList(
         items(pokemonUiDataList) { listItem ->
             PokeCard(
                 pokemon = listItem,
-                onClickCard = onClickCard
+                onClickCard = onClickCard,
+                getPokemonDescription = getPokemonDescription
             )
         }
         item { EmptySpace() }
@@ -187,12 +197,16 @@ private fun PokeList(
 private fun PokeCard(
     pokemon: HomeScreenUiData,
     onClickCard: () -> Unit,
+    getPokemonDescription: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Card(
         modifier = modifier.padding(8.dp),
         elevation = cardElevation(4.dp),
-        onClick = { onClickCard.invoke() }
+        onClick = {
+            getPokemonDescription.invoke(pokemon.name)
+            onClickCard.invoke()
+        }
     ) {
         Box(
             contentAlignment = Alignment.BottomCenter
@@ -232,6 +246,7 @@ private fun EmptySpace() {
 private fun PokeCardPreview() {
     PokeCard(
         pokemon = HomeScreenUiData(name = "ピカチュウ"),
-        onClickCard = {}
+        onClickCard = {},
+        getPokemonDescription = {}
     )
 }

--- a/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
@@ -67,7 +67,7 @@ private fun HomeScreen(
     onClickBack: () -> Unit,
     onClickCard: () -> Unit
 ) {
-    val state by uiState.collectAsState()
+    val state by uiState.collectAsStateWithLifecycle()
 
     when (state) {
         is HomeUiState.Fetched -> {

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/PokemonDetailState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/PokemonDetailState.kt
@@ -34,7 +34,8 @@ data class PokemonDetailScreenUiData(
     val hp: Int = 0,
     val attack: Int = 0,
     val defense: Int = 0,
-    val speed: Int = 0
+    val speed: Int = 0,
+    val imageUri: String = ""
     //TODO 身長
     //TODO 体重
 )

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/PokemonDetailViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/PokemonDetailViewModel.kt
@@ -31,20 +31,27 @@ class PokemonDetailViewModel : ViewModel() {
             repository.getPokemonDescription(pokeName)
         }
             .onSuccess {
+                // ポケモン個体情報取得
+                val pokemonPersonalData = repository.getPokemonPersonalData(pokeName)
+
+                // 名前
                 val name = it.names.firstOrNull { names -> names.language.name == "ja" }?.name ?: ""
 
+                // 説明
                 val description = it.flavorTextEntries.firstOrNull { flavorTextEntries ->
                     flavorTextEntries.language.name == "ja"
                 }?.flavorText ?: ""
 
+                // 分類
                 val genus =
-                    it.genera.firstOrNull { genera -> genera.language.name == "ja" }?.language?.name
-                        ?: ""
+                    it.genera.firstOrNull { genera -> genera.language.name == "ja" }?.genus ?: ""
 
-                val pokemonPersonalData = repository.getPokemonPersonalData(pokeName)
-
+                // タイプ
                 val type: MutableList<String> =
                     pokemonPersonalData.types.map { type -> type.type.name }.toMutableList()
+
+                // 画像
+                val imageUri = pokemonPersonalData.sprites.other.officialArtwork.imgUrl
 
                 pokemonPersonalData.stats.onEach { stats ->
                     _conditionState.update { currentState ->
@@ -68,6 +75,7 @@ class PokemonDetailViewModel : ViewModel() {
                             "speed" -> currentState.copy(
                                 speed = stats.baseStat
                             )
+
                             else -> currentState
                         }
                     }
@@ -80,7 +88,8 @@ class PokemonDetailViewModel : ViewModel() {
                         name = name,
                         type = type,
                         description = description,
-                        genus = genus
+                        genus = genus,
+                        imageUri = imageUri
                     )
                 }
                 _uiState.emit(PokemonDetailUiState.Fetched)


### PR DESCRIPTION
## 対応内容

* ポケモン一覧から任意のポケモンを表示できるよう処理を追加


## レビュー観点

* 実装に違和感ないか


## 苦労したところ
PokemonDetailScreenでstateの監視がうまくいかず苦労した
原因は、NavHostで定義する際に　HomeScreenとPokemonDetailScreenで別のインスタンスを見ていたから
一つのインスタンスを見るよう修正することでstateの監視に成功


## スクリーンショット

| after |
|--------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/c06d5a65-f7fa-42cc-a9bd-e75d953f470a" width="200px"/>|


