### PR TITLE
詳細画面にてポケモンの高さ、重さを取得して表示できるよう修正

### DIFF
--- a/app/src/main/java/com/example/pokebook/model/PokemonPersonalData.kt
+++ b/app/src/main/java/com/example/pokebook/model/PokemonPersonalData.kt
@@ -12,7 +12,9 @@ data class PokemonPersonalData(
     val species: Species,
     val sprites: Sprites,
     val stats: List<Stats>,
-    val types: List<Types>
+    val types: List<Types>,
+    val height:Int,
+    val weight: Int
 )
 
 @Serializable

--- a/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
@@ -200,13 +200,13 @@ private fun BaseInfo(
                 .padding(bottom = 10.dp)
         ) {
             Text(
-                text = "重さ：6.0kg", // TODO API確認
+                text = String.format(stringResource(R.string.pokemon_weight), uiData.weight),
                 fontSize = 20.sp,
                 modifier = modifier
                     .padding(start = 10.dp, end = 10.dp, top = 5.dp)
             )
             Text(
-                text = "高さ：0.4m", // TODO API確認
+                text = String.format(stringResource(R.string.pokemon_height), uiData.height),
                 fontSize = 20.sp,
                 modifier = modifier
                     .padding(start = 10.dp, end = 10.dp, top = 5.dp)

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/PokemonDetailState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/PokemonDetailState.kt
@@ -7,7 +7,7 @@ import java.util.UUID
  */
 sealed class PokemonDetailUiState {
     object Loading : PokemonDetailUiState()
-    object Fetched: PokemonDetailUiState()
+    object Fetched : PokemonDetailUiState()
     object InitialState : PokemonDetailUiState()
 }
 
@@ -35,9 +35,9 @@ data class PokemonDetailScreenUiData(
     val attack: Int = 0,
     val defense: Int = 0,
     val speed: Int = 0,
-    val imageUri: String = ""
-    //TODO 身長
-    //TODO 体重
+    val imageUri: String = "",
+    val height: Int = 0,
+    val weight: Int = 0
 )
 
 /**

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/PokemonDetailViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/PokemonDetailViewModel.kt
@@ -89,7 +89,9 @@ class PokemonDetailViewModel : ViewModel() {
                         type = type,
                         description = description,
                         genus = genus,
-                        imageUri = imageUri
+                        imageUri = imageUri,
+                        height = pokemonPersonalData.height,
+                        weight = pokemonPersonalData.weight
                     )
                 }
                 _uiState.emit(PokemonDetailUiState.Fetched)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,4 +15,6 @@
     <string name="pokemon_attack">攻撃：%s</string>
     <string name="pokemon_defense">防御：%s</string>
     <string name="pokemon_speed">ＳＰＥＥＤ：%s</string>
+    <string name="pokemon_weight">重さ：%s kg</string>
+    <string name="pokemon_height">高さ：%s m</string>
 </resources>


### PR DESCRIPTION
## 対応内容

* 詳細画面にてポケモンの高さ、重さを取得して表示できるよう修正


## レビュー観点

* 実装に違和感ないか



## スクリーンショット

| フシギダネ | リザード |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/e66cca80-9518-4f38-80f8-f036ef8b7094" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/3d8e5f11-37f8-4c3c-90a9-2438722d1941" width="200px"/>|

