### PR TITLE
一覧に表示するポケモン名を日本語に変更

### DIFF
--- a/app/src/main/java/com/example/pokebook/network/PokeApiService.kt
+++ b/app/src/main/java/com/example/pokebook/network/PokeApiService.kt
@@ -6,10 +6,7 @@ import com.example.pokebook.model.PokemonSpecies
 import com.example.pokebook.network.RetrofitInstance.Companion.getRetrofitInstance
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import kotlinx.serialization.json.Json
-import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.OkHttpClient
-import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.http.GET
 import retrofit2.http.Path
@@ -56,7 +53,7 @@ interface PokeApiService {
      * ポケモン個体説明取得
      */
     @GET("pokemon-species/{path}")
-    suspend fun getPokemonDescription(@Path("path") number: String): PokemonSpecies
+    suspend fun getPokemonSpecies(@Path("path") number: String): PokemonSpecies
 }
 
 object PokeApi {

--- a/app/src/main/java/com/example/pokebook/repository/HomeRepository.kt
+++ b/app/src/main/java/com/example/pokebook/repository/HomeRepository.kt
@@ -12,7 +12,7 @@ interface HomeRepository {
 
     suspend fun getPokemonList(offset: String): Pokemon
 
-    suspend fun getPokemonSpecies(number: String): PokemonPersonalData
+    suspend fun getPokemonPersonalData(number: String): PokemonPersonalData
 }
 
 class DefaultHomeRepository : HomeRepository {
@@ -27,7 +27,7 @@ class DefaultHomeRepository : HomeRepository {
         )
     }
 
-    override suspend fun getPokemonSpecies(number: String): PokemonPersonalData {
+    override suspend fun getPokemonPersonalData(number: String): PokemonPersonalData {
         return PokeApi.retrofitService.getPokemonPersonalData(number)
     }
 }

--- a/app/src/main/java/com/example/pokebook/repository/HomeRepository.kt
+++ b/app/src/main/java/com/example/pokebook/repository/HomeRepository.kt
@@ -2,7 +2,9 @@ package com.example.pokebook.repository
 
 import com.example.pokebook.model.Pokemon
 import com.example.pokebook.model.PokemonPersonalData
+import com.example.pokebook.model.PokemonSpecies
 import com.example.pokebook.network.PokeApi
+import retrofit2.http.Path
 
 /**
  * 一覧画面取得に関するリポジトリー
@@ -13,6 +15,7 @@ interface HomeRepository {
     suspend fun getPokemonList(offset: String): Pokemon
 
     suspend fun getPokemonPersonalData(number: String): PokemonPersonalData
+    suspend fun getPokemonSpecies(@Path("path") number: String): PokemonSpecies
 }
 
 class DefaultHomeRepository : HomeRepository {
@@ -29,5 +32,9 @@ class DefaultHomeRepository : HomeRepository {
 
     override suspend fun getPokemonPersonalData(number: String): PokemonPersonalData {
         return PokeApi.retrofitService.getPokemonPersonalData(number)
+    }
+
+    override suspend fun getPokemonSpecies(number: String): PokemonSpecies {
+        return PokeApi.retrofitService.getPokemonSpecies(number)
     }
 }

--- a/app/src/main/java/com/example/pokebook/repository/PokemonDetailRepository.kt
+++ b/app/src/main/java/com/example/pokebook/repository/PokemonDetailRepository.kt
@@ -7,7 +7,7 @@ import retrofit2.http.Path
 
 interface PokemonDetailRepository {
     suspend fun getPokemonPersonalData(@Path("path") number: String): PokemonPersonalData
-    suspend fun getPokemonDescription(@Path("path") number: String): PokemonSpecies
+    suspend fun getPokemonSpecies(@Path("path") number: String): PokemonSpecies
 }
 
 class DefaultPokemonDetailRepository: PokemonDetailRepository{
@@ -15,7 +15,7 @@ class DefaultPokemonDetailRepository: PokemonDetailRepository{
         return PokeApi.retrofitService.getPokemonPersonalData(number)
     }
 
-    override suspend fun getPokemonDescription(number: String): PokemonSpecies {
-        return PokeApi.retrofitService.getPokemonDescription(number)
+    override suspend fun getPokemonSpecies(number: String): PokemonSpecies {
+        return PokeApi.retrofitService.getPokemonSpecies(number)
     }
 }

--- a/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
@@ -179,7 +179,7 @@ private fun PokeCard(
                 contentDescription = null
             )
             Text(
-                text = pokemon.name,
+                text = pokemon.displayName,
                 fontSize = 13.sp,
                 modifier = Modifier
                     .shadow(

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/HomeState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/HomeState.kt
@@ -21,6 +21,7 @@ sealed class HomeUiState {
  */
 data class HomeScreenUiData(
     val name: String = "",
+    var displayName: String ="",
     val url: String = "",
     var imageUri: String = ""
 )

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/HomeViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/HomeViewModel.kt
@@ -75,7 +75,7 @@ class HomeViewModel : ViewModel() {
                         async {
                             pokemonNumber?.let { number ->
                                 // ポケモンのパーソナル情報を取得
-                                repository.getPokemonSpecies(number)
+                                repository.getPokemonPersonalData(number)
                             }
                         }
                     }.awaitAll() //全てのコルーチンが終了するまでまちデータを受け取る

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/PokemonDetailViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/PokemonDetailViewModel.kt
@@ -1,16 +1,13 @@
 package com.example.pokebook.ui.viewModel
 
 import android.util.Log
-import androidx.compose.ui.text.toUpperCase
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.pokebook.model.StatType
 import com.example.pokebook.repository.DefaultPokemonDetailRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import java.util.Locale
 
 class PokemonDetailViewModel : ViewModel() {
     private var _uiState: MutableStateFlow<PokemonDetailUiState> =
@@ -28,7 +25,7 @@ class PokemonDetailViewModel : ViewModel() {
     fun getPokemonDescription(pokeName: String) = viewModelScope.launch {
         _uiState.emit(PokemonDetailUiState.Loading)
         runCatching {
-            repository.getPokemonDescription(pokeName)
+            repository.getPokemonSpecies(pokeName)
         }
             .onSuccess {
                 // ポケモン個体情報取得


### PR DESCRIPTION

## 対応内容

* 日本語に対応したポケモン名をAPIから取得し、一覧表示できるよう対応


## レビュー観点

*実装に違和感ないか。特にHomeViewModel::getPokemonListでasyncスコープが二つ存在しているが実装方法に問題はないか？

## スクリーンショット

| before | after |
|--------|-------|
|<img src="" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/3d5fe857-36b0-49e5-a08a-a9136ff5887d" width="200px"/>|


