### PR TITLE
一覧と詳細でポケモン名と併せてidを表示する処理に変更

### DIFF
--- a/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
@@ -179,7 +179,11 @@ private fun PokeCard(
                 contentDescription = null
             )
             Text(
-                text = pokemon.displayName,
+                text = String.format(
+                    stringResource(R.string.pokemon_name),
+                    pokemon.id,
+                    pokemon.displayName
+                ),
                 fontSize = 13.sp,
                 modifier = Modifier
                     .shadow(

--- a/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
@@ -105,7 +105,11 @@ private fun PokemonDetailScreen(
                 .padding(6.dp)
         ) {
             Text(
-                text = uiData.name,
+                text = String.format(
+                    stringResource(id = R.string.pokemon_name),
+                    uiData.id,
+                    uiData.name
+                ),
                 fontSize = 50.sp,
                 modifier = modifier
                     .align(Alignment.CenterHorizontally),

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/HomeState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/HomeState.kt
@@ -20,8 +20,9 @@ sealed class HomeUiState {
  *　画像URL　
  */
 data class HomeScreenUiData(
+    var id: Int = 0,
     val name: String = "",
-    var displayName: String ="",
+    var displayName: String = "",
     val url: String = "",
     var imageUri: String = ""
 )

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/HomeViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/HomeViewModel.kt
@@ -86,7 +86,7 @@ class HomeViewModel : ViewModel() {
                     }
 
                     // 一覧に表示するポケモンの日本語名を取得
-                    val japanesePokemonNameList = it.results.map { item ->
+                    val pokemonSpeciesList = it.results.map { item ->
                         val pokemonNumber = Uri.parse(item.url).lastPathSegment
                         async {
                             pokemonNumber?.let { number ->
@@ -96,8 +96,9 @@ class HomeViewModel : ViewModel() {
                     }.awaitAll()
                     uiDataList.onEachIndexed { index, item ->
                         item.displayName =
-                            japanesePokemonNameList[index]?.names?.firstOrNull { name -> name.language.name == "ja" }?.name
+                            pokemonSpeciesList[index]?.names?.firstOrNull { name -> name.language.name == "ja" }?.name
                                 ?: ""
+                        item.id = pokemonSpeciesList[index]?.id ?: 0
                     }
                     _uiState.emit(HomeUiState.Fetched(uiDataList = uiDataList))
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,4 +17,5 @@
     <string name="pokemon_speed">ＳＰＥＥＤ：%s</string>
     <string name="pokemon_weight">重さ：%s kg</string>
     <string name="pokemon_height">高さ：%s m</string>
+    <string name="pokemon_name">#%d %s</string>
 </resources>


### PR DESCRIPTION
## 対応内容

* 一覧と詳細でidが表示できるよう修正


## レビュー観点

* 実装に違和感がないか


## スクリーンショット

| 一覧 | 詳細 |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/05f6ec7f-42cb-40c4-9813-4825923b37ba" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/5eb5ee45-8d67-4f31-86ee-f1381b5b9388" width="200px"/>|

