### PR TITLE
各テーマに合わせたデザインが表示できるよう修正

### DIFF
--- a/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.Text
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults.cardElevation
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -117,7 +118,10 @@ private fun PokeList(
     getPokemonDescription: (String) -> Unit,
     lazyListState: LazyGridState
 ) {
-    Column {
+    Column(
+        modifier = Modifier
+            .background(MaterialTheme.colorScheme.background)
+    ) {
         DefaultHeader(
             currentNumberStart = currentNumberStart,
             currentNumberEnd = currentNumberEnd,
@@ -194,13 +198,15 @@ private fun PokeCard(
                     pokemon.displayName
                 ),
                 fontSize = 13.sp,
-                modifier = Modifier
+                color = MaterialTheme.colorScheme.onPrimary,
+                        modifier = Modifier
                     .shadow(
                         elevation = 1.dp,
                         shape = RoundedCornerShape(8.dp)
                     )
                     .padding(bottom = 2.dp)
-                    .background(Color.White, shape = RoundedCornerShape(8.dp))
+                    .background(
+                        color = MaterialTheme.colorScheme.primary, shape = RoundedCornerShape(8.dp))
                     .padding(3.dp)
             )
         }
@@ -216,6 +222,7 @@ private fun DefaultHeader(
 ) {
     Column(
         modifier = Modifier
+            .background(MaterialTheme.colorScheme.background)
             .padding(bottom = 5.dp)
     ) {
         Text(
@@ -224,12 +231,12 @@ private fun DefaultHeader(
                 currentNumberStart,
                 currentNumberEnd
             ),
-            color = Color.Black,
+            color = MaterialTheme.colorScheme.onBackground,
             fontSize = 25.sp,
             modifier = Modifier
                 .padding(2.dp)
                 .align(Alignment.CenterHorizontally)
-                .background(Color.White)
+                .background(MaterialTheme.colorScheme.background)
         )
         Row(
             modifier = Modifier
@@ -244,6 +251,7 @@ private fun DefaultHeader(
             ) {
                 Text(
                     text = stringResource(R.string.back_button),
+                    color = MaterialTheme.colorScheme.onBackground,
                     modifier = Modifier
                         .fillMaxWidth()
                         .border(
@@ -264,6 +272,7 @@ private fun DefaultHeader(
             ) {
                 Text(
                     text = stringResource(R.string.next_button),
+                    color = MaterialTheme.colorScheme.onBackground,
                     modifier = Modifier
                         .fillMaxWidth()
                         .border(

--- a/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -89,6 +90,7 @@ private fun PokemonDetailScreen(
 ) {
     Column(
         modifier = Modifier
+            .background(MaterialTheme.colorScheme.background)
             .verticalScroll(
                 state = rememberScrollState(),
                 reverseScrolling = true
@@ -110,8 +112,8 @@ private fun PokemonDetailScreen(
             verticalArrangement = Arrangement.spacedBy(20.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
+                .background(MaterialTheme.colorScheme.background)
                 .fillMaxSize()
-                .background(Color.White)
                 .padding(6.dp)
         ) {
             Text(
@@ -120,6 +122,7 @@ private fun PokemonDetailScreen(
                     uiData.id,
                     uiData.name
                 ),
+                color = MaterialTheme.colorScheme.onBackground,
                 fontSize = 50.sp,
                 modifier = modifier
                     .align(Alignment.CenterHorizontally),
@@ -129,6 +132,7 @@ private fun PokemonDetailScreen(
                 fontSize = 15.sp,
                 modifier = modifier
                     .align(Alignment.CenterHorizontally),
+                color = MaterialTheme.colorScheme.onBackground
             )
 
             BaseInfo(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,7 +15,7 @@
     <string name="pokemon_attack">攻撃：%s</string>
     <string name="pokemon_defense">防御：%s</string>
     <string name="pokemon_speed">ＳＰＥＥＤ：%s</string>
-    <string name="pokemon_weight">重さ：%s kg</string>
-    <string name="pokemon_height">高さ：%s m</string>
+    <string name="pokemon_weight">重さ：%s g</string>
+    <string name="pokemon_height">高さ：%s cm</string>
     <string name="pokemon_name">#%d %s</string>
 </resources>


### PR DESCRIPTION

## 対応内容

* MaterialTheme.colorSchemeを使って全体的に色の設定を修正


## レビュー観点

* 実装に違和感ないか

## 期待動作

* どのような動作確認を行ったのか？　結果はどうか？

## スクリーンショット

一覧画面
| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/fa8fd89b-92e3-4163-a4b9-7e3b84d00cdb" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/0c7435e0-187c-4956-b900-c3730a94a37f" width="200px"/>|


詳細画面
| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/84b34fa5-84bc-4824-bfe2-fd0e98c59367" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/0bbe8fca-f72c-4942-9a4b-62182dd12a0c" width="200px"/>|

