### PR TITLE
一覧表示時のポケモン名の配色を変更

### DIFF
--- a/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
@@ -198,7 +198,7 @@ private fun PokeCard(
                     pokemon.displayName
                 ),
                 fontSize = 13.sp,
-                color = MaterialTheme.colorScheme.onPrimary,
+                color = MaterialTheme.colorScheme.onSecondary,
                         modifier = Modifier
                     .shadow(
                         elevation = 1.dp,
@@ -206,7 +206,7 @@ private fun PokeCard(
                     )
                     .padding(bottom = 2.dp)
                     .background(
-                        color = MaterialTheme.colorScheme.primary, shape = RoundedCornerShape(8.dp))
+                        color = MaterialTheme.colorScheme.secondary, shape = RoundedCornerShape(8.dp))
                     .padding(3.dp)
             )
         }


### PR DESCRIPTION
## 対応内容

* 色指定を変更


## レビュー観点

* 実装や見た目に違和感がないか



## スクリーンショット

| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/8a412dbc-c7d0-4d3a-ae44-3a55206a1684" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/82ee0a40-466c-4615-81ce-160b0b1735a1" width="200px"/>|



| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/2ecb728f-9563-4fa3-90a9-9eac9d9f5d83" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/09d3382d-40ac-4679-9d58-2b33c01c5c95" width="200px"/>|






