### PR TITLE
Loading画面がテーマに対応した背景色となるよう修正

### DIFF
--- a/app/src/main/java/com/example/pokebook/ui/screen/CommonScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/CommonScreen.kt
@@ -1,9 +1,11 @@
 package com.example.pokebook.ui.screen
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -20,7 +22,9 @@ import com.example.pokebook.R
 fun LoadingScreen(modifier: Modifier = Modifier) {
     Box(
         contentAlignment = Alignment.Center,
-        modifier = modifier.fillMaxSize()
+        modifier = modifier
+            .background(androidx.compose.material3.MaterialTheme.colorScheme.background)
+            .fillMaxSize()
     ) {
         Image(
             modifier = Modifier.size(200.dp),

--- a/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
@@ -199,14 +199,16 @@ private fun PokeCard(
                 ),
                 fontSize = 13.sp,
                 color = MaterialTheme.colorScheme.onSecondary,
-                        modifier = Modifier
+                modifier = Modifier
                     .shadow(
                         elevation = 1.dp,
                         shape = RoundedCornerShape(8.dp)
                     )
                     .padding(bottom = 2.dp)
                     .background(
-                        color = MaterialTheme.colorScheme.secondary, shape = RoundedCornerShape(8.dp))
+                        color = MaterialTheme.colorScheme.secondary,
+                        shape = RoundedCornerShape(8.dp)
+                    )
                     .padding(3.dp)
             )
         }


### PR DESCRIPTION
## 対応内容

* Loading画面の背景色をMaterialTheme.colorSchemeを使ったカラーに修正

## レビュー観点

* 実装や見た目に違和感がないか


## スクリーンショット

| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/5b69ee6d-11b0-47bf-8b35-5c7e3ab454e6" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/6c80a807-e7b2-4288-89bd-26c1ed8ef83d" width="200px"/>|

