### PR TITLE
属性に合わせてタグ表示と画像背景色を出し分けられるよう修正

### DIFF
--- a/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
@@ -102,7 +102,8 @@ private fun PokemonDetailScreen(
                 .clickable { onClickCard.invoke() }
         )
         TitleImage(
-            imageUri = uiData.imageUri
+            imageUri = uiData.imageUri,
+            type = uiData.type.firstOrNull() ?: ""
         )
         Column(
             verticalArrangement = Arrangement.spacedBy(20.dp),
@@ -149,7 +150,8 @@ private fun PokemonDetailScreen(
 
 @Composable
 private fun TitleImage(
-    imageUri: String
+    imageUri: String,
+    type: String
 ) {
     Card(
         modifier = Modifier
@@ -159,7 +161,29 @@ private fun TitleImage(
         Box(
             contentAlignment = Alignment.TopEnd,
             modifier = Modifier
-                .background(Color.Yellow)
+                .background(
+                    when (type) {
+                        TypeName.FIGHTING.typeName -> Color(color = 0xFFEE6969)
+                        TypeName.POISON.typeName -> Color(color = 0xFFAB7ACA)
+                        TypeName.GROUND.typeName -> Color(color = 0xFFC8A841)
+                        TypeName.FLYING.typeName -> Color(color = 0xFF64A7F1)
+                        TypeName.PSYCHIC.typeName -> Color(color = 0xFF9AC30E)
+                        TypeName.BUG.typeName -> Color(color = 0xFF51CB5A)
+                        TypeName.ROCK.typeName -> Color(color = 0xFFFAC727)
+                        TypeName.GHOST.typeName -> Color(color = 0xFF756EB4)
+                        TypeName.DRAGON.typeName -> Color(color = 0xFF9AC30E)
+                        TypeName.DARK.typeName -> Color(color = 0xFFFF8859)
+                        TypeName.STEEL.typeName -> Color(color = 0xFF818AA4)
+                        TypeName.FAIRY.typeName -> Color(color = 0xFFFC7799)
+                        TypeName.FIRE.typeName -> Color(color = 0xFFFFA766)
+                        TypeName.WATER.typeName -> Color(color = 0xFF64C5F7)
+                        TypeName.ELECTRIC.typeName -> Color(color = 0xFFE7D400)
+                        TypeName.GRASS.typeName -> Color(color = 0xFF9AC30E)
+                        TypeName.SHADOW.typeName -> Color(color = 0xFF333333)
+                        TypeName.ICE.typeName -> Color(color = 0xFF60E9F5)
+                        else -> Color(color = 0xFFAEAEAE) //NORMAL,UNKNOWN
+                    }
+                )
         ) {
             Image(
                 imageVector = ImageVector.vectorResource(
@@ -205,11 +229,7 @@ private fun BaseInfo(
             fontSize = 20.sp,
             modifier = modifier.padding(start = 10.dp, end = 10.dp, top = 5.dp)
         )
-        Text(
-            text = String.format(stringResource(R.string.pokemon_type), uiData.type),
-            fontSize = 20.sp,
-            modifier = modifier.padding(start = 10.dp, end = 10.dp, top = 5.dp)
-        )
+        TypeTag(typeList = uiData.type, modifier = modifier)
         Row(
             modifier = modifier
                 .padding(bottom = 10.dp)

--- a/app/src/main/java/com/example/pokebook/ui/screen/TypeTag.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/TypeTag.kt
@@ -1,0 +1,147 @@
+package com.example.pokebook.ui.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.pokebook.R
+import com.example.pokebook.ui.viewModel.PokemonDetailScreenUiData
+import java.lang.reflect.Type
+
+@Preview(showBackground = true)
+@Composable
+fun TypeTagPreview() {
+    TypeTag(typeList = listOf("fighting", "poison", "ground", "shadow"))
+}
+
+
+@Composable
+fun TypeTag(
+    typeList: List<String>,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .padding(top = 5.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.pokemon_type),
+            fontSize = 20.sp,
+            modifier = modifier,
+            color = androidx.compose.material3.MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        typeList.forEach { type ->
+            Text(
+                text = when (type) {
+                    TypeName.FIGHTING.typeName -> stringResource(R.string.type_name_fighting)
+                    TypeName.POISON.typeName -> stringResource(R.string.type_name_poison)
+                    TypeName.GROUND.typeName -> stringResource(R.string.type_name_ground)
+                    TypeName.FLYING.typeName -> stringResource(R.string.type_name_flying)
+                    TypeName.PSYCHIC.typeName -> stringResource(R.string.type_name_psychic)
+                    TypeName.BUG.typeName -> stringResource(R.string.type_name_bug)
+                    TypeName.ROCK.typeName -> stringResource(R.string.type_name_rock)
+                    TypeName.GHOST.typeName -> stringResource(R.string.type_name_ghost)
+                    TypeName.DRAGON.typeName -> stringResource(R.string.type_name_dragon)
+                    TypeName.DARK.typeName -> stringResource(R.string.type_name_dark)
+                    TypeName.STEEL.typeName -> stringResource(R.string.type_name_steel)
+                    TypeName.FAIRY.typeName -> stringResource(R.string.type_name_fairy)
+                    TypeName.FIRE.typeName -> stringResource(R.string.type_name_fire)
+                    TypeName.WATER.typeName -> stringResource(R.string.type_name_water)
+                    TypeName.ELECTRIC.typeName -> stringResource(R.string.type_name_electric)
+                    TypeName.GRASS.typeName -> stringResource(R.string.type_name_grass)
+                    TypeName.SHADOW.typeName -> stringResource(R.string.type_name_shadow)
+                    TypeName.ICE.typeName -> stringResource(R.string.type_name_ice)
+                    TypeName.NORMAL.typeName -> stringResource(R.string.type_name_normal)
+                    TypeName.UNKNOWN.typeName -> stringResource(R.string.type_name_unknown)
+                    else -> type
+                },
+                modifier = modifier
+                    .padding(1.dp)
+                    .background(
+                        color = when (type) {
+                            TypeName.FIGHTING.typeName -> Color(color = 0xFFEE6969)
+                            TypeName.POISON.typeName -> Color(color = 0xFFAB7ACA)
+                            TypeName.GROUND.typeName -> Color(color = 0xFFC8A841)
+                            TypeName.FLYING.typeName -> Color(color = 0xFF64A7F1)
+                            TypeName.PSYCHIC.typeName -> Color(color = 0xFF9AC30E)
+                            TypeName.BUG.typeName -> Color(color = 0xFF51CB5A)
+                            TypeName.ROCK.typeName -> Color(color = 0xFFFAC727)
+                            TypeName.GHOST.typeName -> Color(color = 0xFF756EB4)
+                            TypeName.DRAGON.typeName -> Color(color = 0xFF9AC30E)
+                            TypeName.DARK.typeName -> Color(color = 0xFFFF8859)
+                            TypeName.STEEL.typeName -> Color(color = 0xFF818AA4)
+                            TypeName.FAIRY.typeName -> Color(color = 0xFFFC7799)
+                            TypeName.FIRE.typeName -> Color(color = 0xFFFFA766)
+                            TypeName.WATER.typeName -> Color(color = 0xFF64C5F7)
+                            TypeName.ELECTRIC.typeName -> Color(color = 0xFFE7D400)
+                            TypeName.GRASS.typeName -> Color(color = 0xFF9AC30E)
+                            TypeName.SHADOW.typeName -> Color(color = 0xFF333333)
+                            TypeName.ICE.typeName -> Color(color = 0xFF60E9F5)
+                            else -> Color(color = 0xFFAEAEAE) //NORMAL,UNKNOWN
+                        },
+                        shape = RoundedCornerShape(5.dp)
+                    )
+                    .padding(2.dp),
+                color = Color.White,
+            )
+        }
+    }
+}
+
+/**
+ * ノーマル
+ * かくとう
+ * どく
+ * じめん
+ * ひこう
+ * エスパー
+ * むし
+ * いわ
+ * ゴースト
+ * ドラゴン
+ * あく
+ * はがね
+ * フェアリー
+ * ほのお
+ * みず
+ * でんき
+ * くさ
+ * ダーク
+ * こおり
+ * 未知
+ */
+enum class TypeName(val typeName: String) {
+    NORMAL("normal"),
+    FIGHTING("fighting"),
+    POISON("poison"),
+    GROUND("ground"),
+    FLYING("flying"),
+    PSYCHIC("psychic"),
+    BUG("bug"),
+    ROCK("rock"),
+    GHOST("ghost"),
+    DRAGON("dragon"),
+    DARK("dark"),
+    STEEL("steel"),
+    FAIRY("fairy"),
+    FIRE("fire"),
+    WATER("water"),
+    ELECTRIC("electric"),
+    GRASS("grass"),
+    SHADOW("shadow"),
+    ICE("ice"),
+    UNKNOWN("unknown")
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,7 +10,7 @@
     <string name="back_button">◀︎戻る︎</string>
     <string name="next_button">次へ ▶︎︎</string>
     <string name="pokemon_genus">分類：%s</string>
-    <string name="pokemon_type">タイプ：%s</string>
+    <string name="pokemon_type">タイプ：</string>
     <string name="pokemo_hp">ＨＰ：%s</string>
     <string name="pokemon_attack">攻撃：%s</string>
     <string name="pokemon_defense">防御：%s</string>
@@ -18,4 +18,24 @@
     <string name="pokemon_weight">重さ：%s g</string>
     <string name="pokemon_height">高さ：%s cm</string>
     <string name="pokemon_name">#%d %s</string>
+    <string name="type_name_fighting">かくとう</string>
+    <string name="type_name_poison">どく</string>
+    <string name="type_name_ground">くさ</string>
+    <string name="type_name_flying">ひこう</string>
+    <string name="type_name_bug">むし</string>
+    <string name="type_name_psychic">エスパー</string>
+    <string name="type_name_rock">いわ</string>
+    <string name="type_name_ghost">ゴースト</string>
+    <string name="type_name_dragon">ドラゴン</string>
+    <string name="type_name_dark">あく</string>
+    <string name="type_name_steel">はがね</string>
+    <string name="type_name_fairy">フェアリー</string>
+    <string name="type_name_fire">ほのお</string>
+    <string name="type_name_water">みず</string>
+    <string name="type_name_electric">でんき</string>
+    <string name="type_name_grass">くさ</string>
+    <string name="type_name_shadow">ダーク</string>
+    <string name="type_name_ice">こおり</string>
+    <string name="type_name_normal">ノーマル</string>
+    <string name="type_name_unknown">未知</string>
 </resources>


### PR DESCRIPTION
## 対応内容

* 属性に合わせてタグ表示と画像背景色を出し分けられるよう修正


## レビュー観点

* 実装に違和感ないか



## スクリーンショット

| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/a43eaafa-4c49-4db7-b396-24d00e97e757" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/8bcda317-e6a7-4fd1-a135-e8c218df04e5" width="200px"/>|


