### PR TITLE
一覧表示の画像表示部分の領域を最初から確保するよう修正

### DIFF
--- a/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyGridState
@@ -187,7 +188,9 @@ private fun PokeCard(
                     .data(pokemon.imageUri)
                     .crossfade(true)
                     .build(),
-                modifier = Modifier.padding(bottom = 20.dp),
+                modifier = Modifier
+                    .size(200.dp)
+                    .padding(bottom = 20.dp),
                 contentScale = ContentScale.Crop,
                 contentDescription = null
             )


### PR DESCRIPTION

| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/a31e3006-bc35-4f04-b538-89da22c64f84" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/4424fd7b-2028-4766-a0fb-94d7c0a3a634" width="200px"/>|

![untitled webm]()

