### PR TITLE
検索画面にてタイプ検索押下時該当するポケモン名一覧を取得できるよう実装

### DIFF
--- a/app/src/main/java/com/example/pokebook/model/PokemonPersonalData.kt
+++ b/app/src/main/java/com/example/pokebook/model/PokemonPersonalData.kt
@@ -31,13 +31,13 @@ data class Other(
 @Serializable
 data class OfficialArtwork(
     @SerialName("front_default")
-    val imgUrl: String
+    val imgUrl: String?
 )
 
 @Serializable
 data class Species(
     val name: String,
-    val url: String  // ※1
+    val url: String?  // ※1
 )
 
 @Serializable

--- a/app/src/main/java/com/example/pokebook/model/PokemonTypeSearchResult.kt
+++ b/app/src/main/java/com/example/pokebook/model/PokemonTypeSearchResult.kt
@@ -1,0 +1,20 @@
+package com.example.pokebook.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * タイプ別に検索した結果のポケモンを格納する場所
+ */
+@Serializable
+data class PokemonTypeSearchResult(
+    val pokemon: List<PokemonItem>
+)
+
+@Serializable
+data class PokemonItem(
+    @SerialName("pokemon")
+    val pokemonItem:PokemonListItem
+)
+
+

--- a/app/src/main/java/com/example/pokebook/network/PokeApiService.kt
+++ b/app/src/main/java/com/example/pokebook/network/PokeApiService.kt
@@ -3,6 +3,7 @@ package com.example.pokebook.network
 import com.example.pokebook.model.Pokemon
 import com.example.pokebook.model.PokemonPersonalData
 import com.example.pokebook.model.PokemonSpecies
+import com.example.pokebook.model.PokemonTypeSearchResult
 import com.example.pokebook.network.RetrofitInstance.Companion.getRetrofitInstance
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import kotlinx.serialization.json.Json
@@ -54,6 +55,12 @@ interface PokeApiService {
      */
     @GET("pokemon-species/{path}")
     suspend fun getPokemonSpecies(@Path("path") number: String): PokemonSpecies
+
+    /**
+     * ポケモンタイプ別検索
+     */
+    @GET("type/{path}")
+    suspend fun getPokemonByType(@Path("path") typeNumber: String): PokemonTypeSearchResult
 }
 
 object PokeApi {

--- a/app/src/main/java/com/example/pokebook/repository/SearchRepository.kt
+++ b/app/src/main/java/com/example/pokebook/repository/SearchRepository.kt
@@ -1,0 +1,27 @@
+package com.example.pokebook.repository
+
+import com.example.pokebook.model.PokemonPersonalData
+import com.example.pokebook.model.PokemonSpecies
+import com.example.pokebook.model.PokemonTypeSearchResult
+import com.example.pokebook.network.PokeApi
+import retrofit2.http.Path
+
+interface SearchRepository {
+    suspend fun getPokemonPersonalData(pokemon: String): PokemonPersonalData
+    suspend fun getPokemonByType(@Path("path") typeNumber: String): PokemonTypeSearchResult
+    suspend fun getPokemonSpecies(@Path("path") number: String): PokemonSpecies
+}
+
+class DefaultSearchRepository : SearchRepository {
+    override suspend fun getPokemonPersonalData(pokemon: String): PokemonPersonalData {
+        return PokeApi.retrofitService.getPokemonPersonalData(pokemon)
+    }
+
+    override suspend fun getPokemonByType(typeNumber: String): PokemonTypeSearchResult {
+       return PokeApi.retrofitService.getPokemonByType(typeNumber)
+    }
+
+    override suspend fun getPokemonSpecies(number: String): PokemonSpecies {
+        return PokeApi.retrofitService.getPokemonSpecies(number)
+    }
+}

--- a/app/src/main/java/com/example/pokebook/ui/screen/BottomNavigationScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/BottomNavigationScreen.kt
@@ -2,20 +2,11 @@ package com.example.pokebook.ui.screen
 
 import android.annotation.SuppressLint
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.BottomNavigation
 import androidx.compose.material.BottomNavigationItem
 import androidx.compose.material.Icon
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
-import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Search
@@ -23,25 +14,19 @@ import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
-import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
-import com.example.pokebook.R
-import com.example.pokebook.ui.theme.PokeBookTheme
 import com.example.pokebook.ui.viewModel.HomeViewModel
 import com.example.pokebook.ui.viewModel.PokemonDetailViewModel
+import com.example.pokebook.ui.viewModel.SearchViewModel
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
 /**
@@ -75,38 +60,64 @@ private fun NavigationHost(
     navController: NavHostController
 ) {
     val childNavController = rememberNavController()
+    val searchNavController = rememberNavController()
+
     NavHost(
         navController = navController,
         startDestination = BottomNavItems.Home.route
     ) {
+        val homeViewModel = HomeViewModel()
+        val pokemonDetailViewModel = PokemonDetailViewModel()
+        val searchViewModel = SearchViewModel()
         composable(BottomNavItems.Home.route) {
             NavHost(
                 navController = childNavController,
-                startDestination = "homeScreen"
+                startDestination = "pokemonListScreen"
             ) {
-                val homeViewModel = HomeViewModel()
-                val pokemonDetailViewModel = PokemonDetailViewModel()
-                composable("homeScreen") {
+                composable("pokemonListScreen") {
                     HomeScreen(
                         homeViewModel = homeViewModel,
                         pokemonDetailViewModel = pokemonDetailViewModel,
                         onClickCard = { childNavController.navigate("pokemonDetailScreen") }
                     )
                 }
-
                 composable("pokemonDetailScreen") {
                     PokemonDetailScreen(
                         pokemonDetailViewModel = pokemonDetailViewModel,
-                        onClickCard = { childNavController.navigateUp() }
+                        onClickBackButton = { childNavController.navigateUp() }
                     )
                 }
             }
         }
         composable(BottomNavItems.Search.route) {
-            // TODO viewModel実装後反映
-            SearchScreen(
-                onClickType = {},
-                onClickSearch = {})
+            NavHost(
+                navController = searchNavController,
+                startDestination = "searchScreen"
+            ) {
+                composable("searchScreen") {
+                    SearchScreen(
+                        searchViewModel = searchViewModel,
+                        onClickSearchTypeButton = { searchNavController.navigate("pokemonListScreen") },
+//                        onClickBackButton = { searchNavController.navigateUp() }
+//                    TODO 検索たぶでバックボタンおストクラッシュする
+                    )
+                }
+                composable("pokemonListScreen") {
+                    SearchListScreen(
+                        searchViewModel = searchViewModel,
+                        pokemonDetailViewModel = pokemonDetailViewModel,
+                        onClickCard = { searchNavController.navigate("pokemonDetailScreen") },
+                        onClickBackButton = { searchNavController.navigateUp() }
+                    )
+
+                }
+                composable("pokemonDetailScreen") {
+                    PokemonDetailScreen(
+                        pokemonDetailViewModel = pokemonDetailViewModel,
+                        onClickBackButton = { searchNavController.navigateUp() }
+                    )
+                }
+            }
         }
         composable(BottomNavItems.Like.route) {
             // TODO お気に入り画面

--- a/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
@@ -184,17 +184,19 @@ fun PokeCard(
         Box(
             contentAlignment = Alignment.BottomCenter
         ) {
-            AsyncImage(
-                model = ImageRequest.Builder(context = LocalContext.current)
-                    .data(pokemon.imageUri)
-                    .crossfade(true)
-                    .build(),
-                modifier = Modifier
-                    .size(200.dp)
-                    .padding(bottom = 20.dp),
-                contentScale = ContentScale.Crop,
-                contentDescription = null
-            )
+            pokemon.imageUri?.let{
+                AsyncImage(
+                    model = ImageRequest.Builder(context = LocalContext.current)
+                        .data(pokemon.imageUri)
+                        .crossfade(true)
+                        .build(),
+                    modifier = Modifier
+                        .size(200.dp)
+                        .padding(bottom = 20.dp),
+                    contentScale = ContentScale.Crop,
+                    contentDescription = null
+                )
+            }
             Text(
                 text = String.format(
                     stringResource(R.string.pokemon_name),

--- a/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
@@ -47,12 +47,12 @@ import kotlinx.coroutines.flow.StateFlow
 @Composable
 fun PokemonDetailScreen(
     pokemonDetailViewModel: PokemonDetailViewModel,
-    onClickCard: () -> Unit
+    onClickBackButton: () -> Unit
 ) {
     PokemonDetailScreen(
         uiState = pokemonDetailViewModel.uiState,
         conditionState = pokemonDetailViewModel.conditionState,
-        onClickCard = onClickCard
+        onClickBackButton = onClickBackButton
     )
 }
 
@@ -61,7 +61,7 @@ fun PokemonDetailScreen(
 private fun PokemonDetailScreen(
     uiState: StateFlow<PokemonDetailUiState>,
     conditionState: StateFlow<PokemonDetailScreenUiData>,
-    onClickCard: () -> Unit,
+    onClickBackButton: () -> Unit,
 ) {
     val state by uiState.collectAsStateWithLifecycle()
 
@@ -69,7 +69,7 @@ private fun PokemonDetailScreen(
         is PokemonDetailUiState.Fetched -> {
             PokemonDetailScreen(
                 uiData = conditionState.value,
-                onClickCard = onClickCard
+                onClickBackButton = onClickBackButton
             )
         }
 
@@ -81,7 +81,7 @@ private fun PokemonDetailScreen(
 @Composable
 private fun PokemonDetailScreen(
     uiData: PokemonDetailScreenUiData,
-    onClickCard: () -> Unit,
+    onClickBackButton: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -99,7 +99,7 @@ private fun PokemonDetailScreen(
             contentDescription = null,
             modifier = Modifier
                 .align(Alignment.Start)
-                .clickable { onClickCard.invoke() }
+                .clickable { onClickBackButton.invoke() }
         )
         TitleImage(
             imageUri = uiData.imageUri,
@@ -303,6 +303,6 @@ private fun Ability(
 private fun PokemonDetailScreenPreview() {
     PokemonDetailScreen(
         uiData = PokemonDetailScreenUiData(),
-        onClickCard = {},
+        onClickBackButton = {},
     )
 }

--- a/app/src/main/java/com/example/pokebook/ui/screen/SearchListScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/SearchListScreen.kt
@@ -1,0 +1,177 @@
+package com.example.pokebook.ui.screen
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.pokebook.R
+import com.example.pokebook.ui.viewModel.PokemonDetailViewModel
+import com.example.pokebook.ui.viewModel.PokemonListUiData
+import com.example.pokebook.ui.viewModel.SearchConditionState
+import com.example.pokebook.ui.viewModel.SearchUiState
+import com.example.pokebook.ui.viewModel.SearchViewModel
+import kotlinx.coroutines.flow.StateFlow
+
+
+@Composable
+fun SearchListScreen(
+    searchViewModel: SearchViewModel,
+    pokemonDetailViewModel: PokemonDetailViewModel,
+    onClickCard: () -> Unit,
+    onClickBackButton: () -> Unit
+) {
+    SearchListScreen(
+        uiState = searchViewModel.uiState,
+        conditionState = searchViewModel.conditionState,
+        onClickCard = onClickCard,
+        getPokemonSpecies = pokemonDetailViewModel::getPokemonSpecies
+    )
+}
+
+@SuppressLint("StateFlowValueCalledInComposition")
+@Composable
+private fun SearchListScreen(
+    uiState: StateFlow<SearchUiState>,
+    conditionState: StateFlow<SearchConditionState>,
+    onClickCard: () -> Unit,
+    getPokemonSpecies: (String) -> Unit
+) {
+    val state by uiState.collectAsStateWithLifecycle()
+    val lazyGridState = rememberLazyGridState()
+    val searchWord = conditionState.value.pokemonTypeName
+
+    when (state) {
+        is SearchUiState.Fetched -> {
+            SearchListScreen(
+                pokemonUiDataList = (state as SearchUiState.Fetched).searchList,
+                searchWord = searchWord,
+                onClickCard = onClickCard,
+                getPokemonSpecies = getPokemonSpecies,
+                lazyGridState = lazyGridState
+            )
+        }
+
+        SearchUiState.Loading -> {
+            Column {
+                DefaultHeader(
+                    isSearchListScreen = true,
+                    searchWord = searchWord
+                )
+                LoadingScreen()
+            }
+        }
+
+        else -> {}
+    }
+}
+
+@Composable
+private fun SearchListScreen(
+    pokemonUiDataList: List<PokemonListUiData>,
+    searchWord: String,
+    onClickCard: () -> Unit,
+    getPokemonSpecies: (String) -> Unit,
+    lazyGridState: LazyGridState
+) {
+    Column(
+        modifier = Modifier
+            .background(MaterialTheme.colorScheme.background)
+    ) {
+        DefaultHeader(
+            isSearchListScreen = true,
+            searchWord = searchWord
+        )
+        PokeTypeList(
+            pokemonUiDataList = pokemonUiDataList,
+            onClickCard = onClickCard,
+            getPokemonSpecies = getPokemonSpecies,
+            lazyGridState = lazyGridState
+        )
+    }
+}
+
+@Composable
+private fun PokeTypeList(
+    pokemonUiDataList: List<PokemonListUiData>,
+    onClickCard: () -> Unit,
+    getPokemonSpecies: (String) -> Unit,
+    lazyGridState: LazyGridState
+){
+    LazyVerticalGrid(
+        state = lazyGridState,
+        columns = GridCells.Adaptive(minSize = 150.dp),
+    ) {
+        items(pokemonUiDataList) { listItem ->
+            PokeTypeCard(
+                pokemon = listItem,
+                onClickCard = onClickCard,
+                getPokemonSpecies = getPokemonSpecies
+            )
+        }
+        // 下部がボトムナビゲーションとかぶってしまった為
+        item { Spacer(modifier = Modifier.height(70.dp)) }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun PokeTypeCard(
+    pokemon: PokemonListUiData,
+    onClickCard: () -> Unit,
+    getPokemonSpecies: (String) -> Unit,
+    modifier: Modifier = Modifier
+){
+    Card(
+        modifier = modifier.padding(8.dp),
+        elevation = CardDefaults.cardElevation(4.dp),
+        onClick = {
+            getPokemonSpecies.invoke(pokemon.name)
+            onClickCard.invoke()
+        }
+    ) {
+        Text(
+            text = String.format(
+                stringResource(R.string.pokemon_name),
+                pokemon.id,
+                pokemon.name
+            ),
+            fontSize = 13.sp,
+            color = MaterialTheme.colorScheme.onSecondary,
+            modifier = Modifier
+                .fillMaxWidth()
+                .shadow(
+                    elevation = 1.dp,
+                    shape = RoundedCornerShape(8.dp)
+                )
+                .padding(bottom = 2.dp)
+                .background(
+                    color = MaterialTheme.colorScheme.secondary,
+                    shape = RoundedCornerShape(8.dp)
+                )
+                .padding(3.dp)
+        )
+    }
+}
+

--- a/app/src/main/java/com/example/pokebook/ui/screen/SearchScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/SearchScreen.kt
@@ -7,14 +7,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
@@ -34,12 +33,49 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.pokebook.R
+import com.example.pokebook.ui.viewModel.SearchConditionState
+import com.example.pokebook.ui.viewModel.SearchUiState
+import com.example.pokebook.ui.viewModel.SearchViewModel
+import kotlinx.coroutines.flow.StateFlow
 
 @Composable
 fun SearchScreen(
-    onClickType: (String) -> Unit,
-    onClickSearch: (String) -> Unit,
+    searchViewModel: SearchViewModel,
+    onClickSearchTypeButton: () -> Unit,
+//    onClickBackButton: () -> Unit
+) {
+    SearchScreen(
+        onClickSearchType = searchViewModel::getPokemonByType,
+        onClickSearchName = searchViewModel::getPokemonByName,
+        onClickSearchNumber = searchViewModel::getPokemonByNumber,
+        onClickSearchTypeButton = onClickSearchTypeButton
+    )
+}
+
+@Composable
+private fun SearchScreen(
+    onClickSearchType: (String) -> Unit,
+    onClickSearchName: (String) -> Unit,
+    onClickSearchNumber: (String) -> Unit,
+    onClickSearchTypeButton: () -> Unit
+) {
+    SearchScreen(
+        onClickSearchType = onClickSearchType,
+        onClickSearchName = onClickSearchName,
+        onClickSearchNumber = onClickSearchNumber,
+        onClickSearchTypeButton = onClickSearchTypeButton,
+        modifier = Modifier
+    )
+}
+
+@Composable
+private fun SearchScreen(
+    onClickSearchType: (String) -> Unit,
+    onClickSearchName: (String) -> Unit,
+    onClickSearchNumber: (String) -> Unit,
+    onClickSearchTypeButton: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     var valueName by remember { mutableStateOf("") }
@@ -52,16 +88,20 @@ fun SearchScreen(
             .fillMaxSize()
             .background(androidx.compose.material3.MaterialTheme.colorScheme.background)
     ) {
-        SearchType(onClickType = onClickType)
+        SearchType(
+            onClickType = onClickSearchType,
+            onClickSearchTypeButton = onClickSearchTypeButton
+        )
         SearchName(
             value = valueName,
             onValueChange = { valueName = it },
+            onClickSearchName = onClickSearchName,
             modifier = modifier
         )
         SearchNumber(
             value = valueNumber,
             onValueChange = { valueNumber = it },
-            onClickSearch = onClickSearch,
+            onClickSearchNumber = onClickSearchNumber,
             modifier = modifier
         )
     }
@@ -74,6 +114,7 @@ fun SearchScreen(
 @Composable
 private fun SearchType(
     onClickType: (String) -> Unit,
+    onClickSearchTypeButton: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -127,7 +168,33 @@ private fun SearchType(
                             shape = RoundedCornerShape(5.dp),
                         )
                         .padding(2.dp)
-                        .clickable { onClickType.invoke(item) }
+                        .clickable {
+                            val typeNumber = when (item) {
+                                TypeName.FIGHTING.jaTypeName -> TypeName.FIGHTING.number
+                                TypeName.POISON.jaTypeName -> TypeName.POISON.number
+                                TypeName.GROUND.jaTypeName -> TypeName.GROUND.number
+                                TypeName.FLYING.jaTypeName -> TypeName.FLYING.number
+                                TypeName.PSYCHIC.jaTypeName -> TypeName.PSYCHIC.number
+                                TypeName.BUG.jaTypeName -> TypeName.BUG.number
+                                TypeName.ROCK.jaTypeName -> TypeName.ROCK.number
+                                TypeName.GHOST.jaTypeName -> TypeName.GHOST.number
+                                TypeName.DRAGON.jaTypeName -> TypeName.DRAGON.number
+                                TypeName.DARK.jaTypeName -> TypeName.DARK.number
+                                TypeName.STEEL.jaTypeName -> TypeName.STEEL.number
+                                TypeName.FAIRY.jaTypeName -> TypeName.FAIRY.number
+                                TypeName.FIRE.jaTypeName -> TypeName.FIRE.number
+                                TypeName.WATER.jaTypeName -> TypeName.WATER.number
+                                TypeName.ELECTRIC.jaTypeName -> TypeName.ELECTRIC.number
+                                TypeName.GRASS.jaTypeName -> TypeName.GRASS.number
+                                TypeName.SHADOW.jaTypeName -> TypeName.SHADOW.number
+                                TypeName.ICE.jaTypeName -> TypeName.ICE.number
+                                TypeName.NORMAL.jaTypeName -> TypeName.NORMAL.number
+                                TypeName.UNKNOWN.jaTypeName -> TypeName.UNKNOWN.number
+                                else -> ""
+                            }
+                            onClickType.invoke(typeNumber)
+                            onClickSearchTypeButton.invoke()
+                        }
                 )
             }
         }
@@ -143,6 +210,7 @@ private fun SearchType(
 private fun SearchName(
     value: String,
     onValueChange: (String) -> Unit,
+    onClickSearchName: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -172,9 +240,7 @@ private fun SearchName(
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text)
             )
             Button(
-                onClick = {
-                    // TODO 名前で検索
-                },
+                onClick = { onClickSearchName.invoke(value) },
                 modifier = modifier
                     .padding(2.dp),
                 shape = RoundedCornerShape(4.dp)
@@ -197,7 +263,7 @@ private fun SearchName(
 private fun SearchNumber(
     value: String,
     onValueChange: (String) -> Unit,
-    onClickSearch: (String) -> Unit,
+    onClickSearchNumber: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -227,7 +293,7 @@ private fun SearchNumber(
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
             )
             Button(
-                onClick = { onClickSearch.invoke(value) },
+                onClick = { onClickSearchNumber.invoke(value) },
                 modifier = modifier
                     .padding(2.dp),
                 shape = RoundedCornerShape(4.dp)
@@ -243,19 +309,6 @@ private fun SearchNumber(
 
 @Preview(showBackground = true)
 @Composable
-private fun SearchTypePreview() {
-    SearchType({})
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun SearchNamePreview() {
-    SearchName("ピカチュウ", {})
-}
-
-@Preview(showBackground = true)
-@Composable
 private fun SearchNumberPreview() {
     SearchNumber("25", {}, {})
 }
-

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/HomeState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/HomeState.kt
@@ -8,23 +8,25 @@ import java.util.UUID
 sealed class HomeUiState {
     object Loading : HomeUiState()
     data class Fetched(
-        val uiDataList: MutableList<HomeScreenUiData>
+        val uiDataList: MutableList<PokemonListUiData>
     ) : HomeUiState()
 
     object InitialState : HomeUiState()
 }
 
 /**
+ *　id
  *　名前
+ *　ポケモンの説明
  *　ポケモン個体情報取得用URL
  *　画像URL　
  */
-data class HomeScreenUiData(
+data class PokemonListUiData(
     var id: Int = 0,
     val name: String = "",
     var displayName: String = "",
     val url: String = "",
-    var imageUri: String = ""
+    var imageUri: String? = ""
 )
 
 data class HomeScreenConditionState(

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/HomeViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/HomeViewModel.kt
@@ -39,7 +39,7 @@ class HomeViewModel : ViewModel() {
 // ----------------------------------------------------
 
     private val repository = DefaultHomeRepository()
-    private val uiDataList = mutableListOf<HomeScreenUiData>()
+    private val uiDataList = mutableListOf<PokemonListUiData>()
 
     init {
         getPokemonList(true)
@@ -65,7 +65,7 @@ class HomeViewModel : ViewModel() {
                     uiDataList.clear()
                     updateConditionState(it)
                     uiDataList += it.results.map { item ->
-                        HomeScreenUiData(
+                        PokemonListUiData(
                             name = item.name,
                             url = item.url
                         )
@@ -141,3 +141,4 @@ class HomeViewModel : ViewModel() {
         }
     }
 }
+

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/PokemonDetailViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/PokemonDetailViewModel.kt
@@ -22,79 +22,77 @@ class PokemonDetailViewModel : ViewModel() {
     /**
      *　ポケモンの種類に関する情報を取得
      */
-    fun getPokemonDescription(pokeName: String) = viewModelScope.launch {
+    fun getPokemonSpecies(pokeName: String) = viewModelScope.launch {
         _uiState.emit(PokemonDetailUiState.Loading)
         runCatching {
             repository.getPokemonSpecies(pokeName)
-        }
-            .onSuccess {
-                // ポケモン個体情報取得
-                val pokemonPersonalData = repository.getPokemonPersonalData(pokeName)
+        }.onSuccess {
+            // ポケモン個体情報取得
+            val pokemonPersonalData = repository.getPokemonPersonalData(pokeName)
 
-                // 名前
-                val name = it.names.firstOrNull { names -> names.language.name == "ja" }?.name ?: ""
+            // 名前
+            val name = it.names.firstOrNull { names -> names.language.name == "ja" }?.name ?: ""
 
-                // 説明
-                val description = it.flavorTextEntries.firstOrNull { flavorTextEntries ->
-                    flavorTextEntries.language.name == "ja"
-                }?.flavorText ?: ""
+            // 説明
+            val description = it.flavorTextEntries.firstOrNull { flavorTextEntries ->
+                flavorTextEntries.language.name == "ja"
+            }?.flavorText ?: ""
 
-                // 分類
-                val genus =
-                    it.genera.firstOrNull { genera -> genera.language.name == "ja" }?.genus ?: ""
+            // 分類
+            val genus =
+                it.genera.firstOrNull { genera -> genera.language.name == "ja" }?.genus ?: ""
 
-                // タイプ
-                val type: MutableList<String> =
-                    pokemonPersonalData.types.map { type -> type.type.name }.toMutableList()
+            // タイプ
+            val type: MutableList<String> =
+                pokemonPersonalData.types.map { type -> type.type.name }.toMutableList()
 
-                // 画像
-                val imageUri = pokemonPersonalData.sprites.other.officialArtwork.imgUrl
+            // 画像
+            val imageUri = pokemonPersonalData.sprites.other.officialArtwork.imgUrl
 
-                pokemonPersonalData.stats.onEach { stats ->
-                    _conditionState.update { currentState ->
+            pokemonPersonalData.stats.onEach { stats ->
+                _conditionState.update { currentState ->
 
-                        // TODO enumで分岐したい
-                        when (stats.stat.name) {
-                            "hp" -> {
-                                currentState.copy(
-                                    hp = stats.baseStat
-                                )
-                            }
-
-                            "attack" -> currentState.copy(
-                                attack = stats.baseStat
+                    // TODO enumで分岐したい
+                    when (stats.stat.name) {
+                        "hp" -> {
+                            currentState.copy(
+                                hp = stats.baseStat
                             )
-
-                            "defense" -> currentState.copy(
-                                defense = stats.baseStat
-                            )
-
-                            "speed" -> currentState.copy(
-                                speed = stats.baseStat
-                            )
-
-                            else -> currentState
                         }
+
+                        "attack" -> currentState.copy(
+                            attack = stats.baseStat
+                        )
+
+                        "defense" -> currentState.copy(
+                            defense = stats.baseStat
+                        )
+
+                        "speed" -> currentState.copy(
+                            speed = stats.baseStat
+                        )
+
+                        else -> currentState
                     }
                 }
+            }
 
-                // id 日本語名　説明　属性
-                _conditionState.update { currentState ->
-                    currentState.copy(
-                        id = it.id,
-                        name = name,
-                        type = type,
-                        description = description,
-                        genus = genus,
-                        imageUri = imageUri,
-                        height = pokemonPersonalData.height,
-                        weight = pokemonPersonalData.weight
-                    )
-                }
-                _uiState.emit(PokemonDetailUiState.Fetched)
+            // id 日本語名　説明　属性
+            _conditionState.update { currentState ->
+                currentState.copy(
+                    id = it.id,
+                    name = name,
+                    type = type,
+                    description = description,
+                    genus = genus,
+                    imageUri = imageUri ?: "",
+                    height = pokemonPersonalData.height,
+                    weight = pokemonPersonalData.weight
+                )
             }
-            .onFailure {
-                Log.d("error", "e[getPokemonList]:$it")
-            }
+            _uiState.emit(PokemonDetailUiState.Fetched)
+        }.onFailure {
+            Log.d("error", "e[getPokemonList]:$it")
+        }
     }
 }

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/SearchState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/SearchState.kt
@@ -1,0 +1,32 @@
+package com.example.pokebook.ui.viewModel
+
+import com.example.pokebook.model.PokemonListItem
+import com.example.pokebook.ui.screen.TypeName
+import java.util.UUID
+
+/**
+ * 検索画面の状態に関する情報
+ */
+sealed class SearchUiState {
+    object Loading : SearchUiState()
+    data class Fetched(
+        val searchList:List<PokemonListUiData>
+    ): SearchUiState()
+    object InitialState : SearchUiState()
+}
+
+data class SearchConditionState(
+    val pokemonNumber: String = "",
+    val pokemonName: String ="",
+    val pokemonTypeName: String = ""
+)
+
+/**
+ * エラー表示に関する情報
+ */
+sealed class SearchUiEvent(
+    // ワンショットのイベントとして管理
+    val id: Long = UUID.randomUUID().mostSignificantBits
+) {
+    data class Error(val e: Throwable) : SearchUiEvent()
+}

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/SearchViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/SearchViewModel.kt
@@ -1,0 +1,143 @@
+package com.example.pokebook.ui.viewModel
+
+import android.net.Uri
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.pokebook.repository.DefaultSearchRepository
+import com.example.pokebook.ui.screen.TypeName
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class SearchViewModel : ViewModel() {
+    private var _uiState: MutableStateFlow<SearchUiState> =
+        MutableStateFlow(SearchUiState.InitialState)
+    val uiState = _uiState.asStateFlow()
+
+    private val repository = DefaultSearchRepository()
+
+    private var _conditionState: MutableStateFlow<SearchConditionState> =
+        MutableStateFlow(SearchConditionState())
+    val conditionState = _conditionState.asStateFlow()
+    private val uiDataList = mutableListOf<PokemonListUiData>()
+
+    /**
+     * Type検索
+     */
+    fun getPokemonByType(typeNumber: String) = viewModelScope.launch {
+        _uiState.emit(SearchUiState.Loading)
+        runCatching {
+            repository.getPokemonByType(typeNumber)
+        }.onSuccess {
+            uiDataList.clear()
+            uiDataList += it.pokemon.map { item ->
+                PokemonListUiData(
+                    name = item.pokemonItem.name,
+                    url = item.pokemonItem.url
+                )
+            }.toMutableList()
+            // 一覧に表示する画像を取得
+//            val imageUriList = it.pokemon.map { item ->
+//                val pokemonNumber = Uri.parse(item.pokemonItem.url).lastPathSegment
+//                Log.d("test","pokemonNumber：$pokemonNumber")
+//                async {
+//                    pokemonNumber?.let { number ->
+//                        // ポケモンのパーソナル情報を取得
+//                        repository.getPokemonPersonalData(number).apply {
+//                            Log.d("test","getPokemonPersonalData：${this.sprites.other.officialArtwork.imgUrl}")
+//                        }
+//                    }
+//                }
+//            }.awaitAll()
+//            Log.d("test","imageUriList：$imageUriList")
+//            uiDataList.onEachIndexed { index, item ->
+//                item.imageUri =
+//                    imageUriList[index]?.sprites?.other?.officialArtwork?.imgUrl ?: ""
+//            }
+//            Log.d("test","画像URL取得されているはず：$uiDataList")
+            //　一覧に表示するポケモンの日本語名を取得
+//            val pokemonSpeciesList = it.pokemon.map { item ->
+//                val pokemonNumber = Uri.parse(item.pokemonItem.url).lastPathSegment
+//                async {
+//                    pokemonNumber?.let { number ->
+//                        repository.getPokemonSpecies(number).apply {
+//                            Log.d("test","getPokemonSpecies：$this")
+//                        }
+//                    }
+//                }
+//            }.awaitAll()
+//            Log.d("test","pokemonSpeciesList：$pokemonSpeciesList")
+//            uiDataList.onEachIndexed { index, item ->
+//                item.displayName =
+//                    pokemonSpeciesList[index]?.names?.firstOrNull { name -> name.language.name == "ja" }?.name
+//                        ?: ""
+//                item.id = pokemonSpeciesList[index]?.id ?: 0
+//            }
+//            Log.d("test","名前・id取得されているはず：$uiDataList")
+            _conditionState.update { currentState ->
+                val typeName = when (typeNumber) {
+                    TypeName.FIGHTING.number -> TypeName.FIGHTING.jaTypeName
+                    TypeName.POISON.number -> TypeName.POISON.jaTypeName
+                    TypeName.GROUND.number -> TypeName.GROUND.jaTypeName
+                    TypeName.FLYING.number -> TypeName.FLYING.jaTypeName
+                    TypeName.PSYCHIC.number -> TypeName.PSYCHIC.jaTypeName
+                    TypeName.BUG.number -> TypeName.BUG.jaTypeName
+                    TypeName.ROCK.number -> TypeName.ROCK.jaTypeName
+                    TypeName.GHOST.number -> TypeName.GHOST.jaTypeName
+                    TypeName.DRAGON.number -> TypeName.DRAGON.jaTypeName
+                    TypeName.DARK.number -> TypeName.DARK.jaTypeName
+                    TypeName.STEEL.number -> TypeName.STEEL.jaTypeName
+                    TypeName.FAIRY.number -> TypeName.FAIRY.jaTypeName
+                    TypeName.FIRE.number -> TypeName.FIRE.jaTypeName
+                    TypeName.WATER.number -> TypeName.WATER.jaTypeName
+                    TypeName.ELECTRIC.number -> TypeName.ELECTRIC.jaTypeName
+                    TypeName.GRASS.number -> TypeName.GRASS.jaTypeName
+                    TypeName.SHADOW.number -> TypeName.SHADOW.jaTypeName
+                    TypeName.ICE.number -> TypeName.ICE.jaTypeName
+                    TypeName.NORMAL.number -> TypeName.NORMAL.jaTypeName
+                    TypeName.UNKNOWN.number -> TypeName.UNKNOWN.jaTypeName
+                    else -> ""
+                }
+                currentState.copy(
+                    pokemonTypeName = typeName
+                )
+            }
+            Log.d("test", "uiDataList:$uiDataList")
+            _uiState.emit(SearchUiState.Fetched(searchList = uiDataList))
+        }.onFailure {
+            Log.d("error", "e[getPokemonList]:$it")
+        }
+    }
+
+    /**
+     * 名前検索
+     */
+    fun getPokemonByName(name: String) = viewModelScope.launch {
+        _uiState.emit(SearchUiState.Loading)
+        runCatching {
+            repository.getPokemonPersonalData(name)
+        }.onSuccess {
+            // TODO 返ってきたURLから個別情報取得する
+        }.onFailure {
+            Log.d("error", "e[getPokemonList]:$it")
+        }
+    }
+
+    /**
+     * 図鑑番号検索
+     */
+    fun getPokemonByNumber(number: String) = viewModelScope.launch {
+        _uiState.emit(SearchUiState.Loading)
+        runCatching {
+            repository.getPokemonPersonalData(number)
+        }.onSuccess {
+            // TODO 返ってきたURLから個別情報取得する
+        }.onFailure {
+            Log.d("error", "e[getPokemonList]:$it")
+        }
+    }
+}

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -8,7 +8,7 @@
     </array>
 
     <string-array name="all_types">
-        <item>@string/type_name_fire</item>
+        <item>@string/type_name_fighting</item>
         <item>@string/type_name_poison</item>
         <item>@string/type_name_ground</item>
         <item>@string/type_name_flying</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
     <string name="icon_setting">setting</string>
     <string name="loading">loading</string>
     <string name="loading_failed">Failed to load</string>
-    <string name="displayedNumber">#%s 〜 #%s</string>
+    <string name="header_title_displayed_number">#%s 〜 #%s</string>
     <string name="back_button">◀︎戻る︎</string>
     <string name="next_button">次へ ▶︎︎</string>
     <string name="pokemon_genus">分類：%s</string>
@@ -43,4 +43,5 @@
     <string name="search_button">検索</string>
     <string name="search_name_title">ポケモン名検索</string>
     <string name="search_number">図鑑番号で検索</string>
+    <string name="header_title_search_list">「%s」の検索結果一覧</string>
 </resources>


### PR DESCRIPTION
## 対応内容

* 検索画面からタイプ検索をできるよう対応。ただし、検索結果は名前のみの仮表示（英名）
* 連続でAPIを叩く必要があり処理が間に合わずクラッシュしているため、初回起動でデータベースに保存するなど根本的な見直しが必要。
* BottomNavigationも検索タブで戻キー押下後再度検索タブ押下するとクラッシュ発生
* NavHostをネストする場合の設計について調査が必要


## スクリーンショット

ひとまず英名一覧が取得できることのみを確認
idや画像取得に関しては方法を要検討
| after |
|--------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/496c9eef-ef4a-4189-a224-535c570caec3" width="200px"/>|

