### PR TITLE
高さと重さの単位設定に誤りがあったため修正

### DIFF
--- a/app/src/main/java/com/example/pokebook/ui/viewModel/PokemonDetailState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/PokemonDetailState.kt
@@ -36,8 +36,8 @@ data class PokemonDetailScreenUiData(
     val defense: Int = 0,
     val speed: Int = 0,
     val imageUri: String = "",
-    val height: Int = 0,
-    val weight: Int = 0
+    val height: Double = 0.0,
+    val weight: Double = 0.0
 )
 
 /**

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/PokemonDetailViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/PokemonDetailViewModel.kt
@@ -86,8 +86,8 @@ class PokemonDetailViewModel : ViewModel() {
                     description = description,
                     genus = genus,
                     imageUri = imageUri ?: "",
-                    height = pokemonPersonalData.height,
-                    weight = pokemonPersonalData.weight
+                    height = pokemonPersonalData.height/10.0,
+                    weight = pokemonPersonalData.weight/10.0
                 )
             }
             _uiState.emit(PokemonDetailUiState.Fetched)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,8 +15,8 @@
     <string name="pokemon_attack">攻撃：%s</string>
     <string name="pokemon_defense">防御：%s</string>
     <string name="pokemon_speed">ＳＰＥＥＤ：%s</string>
-    <string name="pokemon_weight">重さ：%s g</string>
-    <string name="pokemon_height">高さ：%s cm</string>
+    <string name="pokemon_weight">重さ：%.1f kg</string>
+    <string name="pokemon_height">高さ：%.1f m</string>
     <string name="pokemon_name">#%d %s</string>
     <string name="type_name_fighting">かくとう</string>
     <string name="type_name_poison">どく</string>


### PR DESCRIPTION

## 対応内容

* ポケモンの高さと重さをAPIのレスポンスから計算して表示するように変更


## スクリーンショット

| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/bf8497f5-5a3f-41f3-ab84-734247bb7451" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/516ec7c5-a1d2-406a-9f53-4ba690cd16cb" width="200px"/>|

