### PR TITLE
詳細画面でポケモン名が一行で入りきらない事象を修正

### DIFF
--- a/app/src/main/java/com/example/pokebook/ui/screen/CommonScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/CommonScreen.kt
@@ -8,11 +8,18 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.example.pokebook.R
 
 /**
@@ -45,4 +52,46 @@ fun ErrorScreen(modifier: Modifier = Modifier) {
     ) {
         Text(stringResource(R.string.loading_failed))
     }
+}
+
+/**
+ * 文字サイズの自動調整
+ */
+@Composable
+fun AutoSizeableText(
+    text: String,
+    color: Color,
+    maxTextSize: Int = 50,
+    minTextSize: Int = 40,
+    modifier: Modifier
+) {
+    var textSize by remember { mutableStateOf(maxTextSize) }
+    val checked = remember(text) { mutableMapOf<Int, Boolean?>() }
+    var overflow by remember { mutableStateOf(TextOverflow.Clip) }
+
+    Text(
+        text = text,
+        color = color,
+        fontSize = textSize.sp,
+        maxLines = 1,
+        overflow = overflow,
+        modifier = modifier,
+        onTextLayout = {
+            if (it.hasVisualOverflow) {
+                checked[textSize] = true
+                if (textSize > minTextSize) {
+                    textSize -= 1
+                } else {
+                    overflow = TextOverflow.Ellipsis
+                }
+            } else {
+                checked[textSize] = false
+                if (textSize < maxTextSize) {
+                    if (checked[textSize + 1] == null) {
+                        textSize += 1
+                    }
+                }
+            }
+        }
+    )
 }

--- a/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -113,16 +114,15 @@ private fun PokemonDetailScreen(
                 .fillMaxSize()
                 .padding(6.dp)
         ) {
-            Text(
+            AutoSizeableText(
                 text = String.format(
                     stringResource(id = R.string.pokemon_name),
                     uiData.id,
                     uiData.name
                 ),
                 color = MaterialTheme.colorScheme.onBackground,
-                fontSize = 50.sp,
                 modifier = modifier
-                    .align(Alignment.CenterHorizontally),
+                    .align(Alignment.CenterHorizontally)
             )
             Text(
                 text = uiData.description,


### PR DESCRIPTION
## 対応内容
* 一行で収まっているかを確認し、収まっていない場合は文字サイズを小さくできるようにした


## スクリーンショット

| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/9738b405-ad00-4ccb-ae89-1918b104e996" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/878ea7cc-1e73-496e-ac0b-c60b370ecec8" width="200px"/>|

