### PR TITLE
ポケモン一覧と詳細で表示されるポケモンが違う場合がある

### DIFF
--- a/app/src/main/java/com/example/pokebook/model/PokemonPersonalData.kt
+++ b/app/src/main/java/com/example/pokebook/model/PokemonPersonalData.kt
@@ -107,7 +107,6 @@ data class Genera(
     val language: Language
 )
 
-// TODO これを使いたい
 enum class StatType(val type: String){
     HP("hp"),
     ATTACK("attack"),

--- a/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
@@ -68,7 +68,7 @@ fun HomeScreen(
         onClickBack = homeViewModel::onClickBack,
         onClickCard = onClickCard,
         updateIsFirst = homeViewModel::updateIsFirst,
-        getPokemonSpecies = pokemonDetailViewModel::getPokemonSpecies
+        getPokemonSpecies = pokemonDetailViewModel::getPokemonSpeciesByNumber
     )
 }
 
@@ -81,7 +81,7 @@ private fun HomeScreen(
     onClickBack: () -> Unit,
     onClickCard: () -> Unit,
     updateIsFirst: (Boolean) -> Unit,
-    getPokemonSpecies: (Int) -> Unit
+    getPokemonSpecies: (PokemonListUiData) -> Unit
 ) {
     val state by uiState.collectAsStateWithLifecycle()
     val lazyGridState = rememberLazyGridState()
@@ -133,7 +133,7 @@ private fun PokeList(
     onClickBack: () -> Unit,
     onClickCard: () -> Unit,
     updateIsFirst: (Boolean) -> Unit,
-    getPokemonSpecies: (Int) -> Unit,
+    getPokemonSpecies: (PokemonListUiData) -> Unit,
     lazyGridState: LazyGridState,
     coroutineScope: CoroutineScope
 ) {
@@ -171,7 +171,7 @@ fun PokeList(
     isFirst: Boolean,
     onClickCard: () -> Unit,
     updateIsFirst: (Boolean) -> Unit,
-    getPokemonSpecies: (Int) -> Unit,
+    getPokemonSpecies: (PokemonListUiData) -> Unit,
     lazyGridState: LazyGridState,
     coroutineScope: CoroutineScope
 ) {
@@ -204,14 +204,14 @@ fun PokeList(
 fun PokeCard(
     pokemon: PokemonListUiData,
     onClickCard: () -> Unit,
-    getPokemonSpecies: (Int) -> Unit,
+    getPokemonSpecies: (PokemonListUiData) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Card(
         modifier = modifier.padding(8.dp),
         elevation = cardElevation(4.dp),
         onClick = {
-            getPokemonSpecies.invoke(pokemon.id)
+            getPokemonSpecies.invoke(pokemon)
             onClickCard.invoke()
         }
     ) {

--- a/app/src/main/java/com/example/pokebook/ui/screen/SearchListScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/SearchListScreen.kt
@@ -59,7 +59,7 @@ fun SearchListScreen(
         onClickCard = onClickCard,
         updateButtonStates = searchViewModel::updateButtonStates,
         updateIsFirst = searchViewModel::updateIsFirst,
-        getPokemonSpecies = pokemonDetailViewModel::getPokemonSpecies,
+        getPokemonSpecies = pokemonDetailViewModel::getPokemonSpeciesByNumber,
         onClickBackSearchScreen = onClickBackSearchScreen
     )
 }
@@ -74,7 +74,7 @@ private fun SearchListScreen(
     onClickCard: () -> Unit,
     updateButtonStates: (Boolean, Boolean) -> Unit,
     updateIsFirst: (Boolean) -> Unit,
-    getPokemonSpecies: (Int) -> Unit,
+    getPokemonSpecies: (PokemonListUiData) -> Unit,
     onClickBackSearchScreen: () -> Unit
 ) {
     val state by uiState.collectAsStateWithLifecycle()
@@ -137,7 +137,7 @@ private fun SearchListScreen(
     onClickCard: () -> Unit,
     updateButtonStates: (Boolean, Boolean) -> Unit,
     updateIsFirst: (Boolean) -> Unit,
-    getPokemonSpecies: (Int) -> Unit,
+    getPokemonSpecies: (PokemonListUiData) -> Unit,
     lazyGridState: LazyGridState,
     coroutineScope: CoroutineScope
 ) {
@@ -174,7 +174,7 @@ private fun PokeTypeList(
     isFirst: Boolean,
     onClickCard: () -> Unit,
     updateIsFirst: (Boolean) -> Unit,
-    getPokemonSpecies: (Int) -> Unit,
+    getPokemonSpecies: (PokemonListUiData) -> Unit,
     lazyGridState: LazyGridState,
     coroutineScope: CoroutineScope
 ) {
@@ -208,14 +208,14 @@ private fun PokeTypeList(
 private fun PokeTypeCard(
     pokemon: PokemonListUiData,
     onClickCard: () -> Unit,
-    getPokemonSpecies: (Int) -> Unit,
+    getPokemonSpecies: (PokemonListUiData) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Card(
         modifier = modifier.padding(8.dp),
         elevation = CardDefaults.cardElevation(4.dp),
         onClick = {
-            getPokemonSpecies.invoke(pokemon.id)
+            getPokemonSpecies.invoke(pokemon)
             onClickCard.invoke()
         }
     ) {

--- a/app/src/main/java/com/example/pokebook/ui/screen/SearchScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/SearchScreen.kt
@@ -10,8 +10,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.grid.LazyGridState
-import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
@@ -25,21 +23,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.pokebook.R
 import com.example.pokebook.ui.viewModel.PokemonDetailViewModel
-import com.example.pokebook.ui.viewModel.SearchConditionState
-import com.example.pokebook.ui.viewModel.SearchUiState
 import com.example.pokebook.ui.viewModel.SearchViewModel
-import kotlinx.coroutines.flow.StateFlow
 
 @Composable
 fun SearchScreen(
@@ -53,7 +45,7 @@ fun SearchScreen(
     SearchScreen(
         onClickSearchType = searchViewModel::getPokemonByType,
         onClickSearchName = searchViewModel::getPokemonByName,
-        onClickSearchNumber = pokemonDetailViewModel::getPokemonSpecies,
+        onClickSearchNumber = pokemonDetailViewModel::getPokemonSpeciesByNumber,
         onClickSearchPokemonNumber = onClickSearchPokemonNumber,
         onClickSearchTypeButton = onClickSearchTypeButton
     )

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/HomeViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/HomeViewModel.kt
@@ -5,6 +5,8 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.pokebook.model.Pokemon
+import com.example.pokebook.model.PokemonPersonalData
+import com.example.pokebook.model.PokemonSpecies
 import com.example.pokebook.repository.DefaultHomeRepository
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -72,7 +74,7 @@ class HomeViewModel : ViewModel(), DefaultHeader {
                         )
                     }.toMutableList()
                     // 一覧に表示する画像を取得
-                    val imageUriList = it.results.map { item ->
+                    val pokemonPersonalDataList = it.results.map { item ->
                         val pokemonNumber = Uri.parse(item.url).lastPathSegment
                         async {
                             pokemonNumber?.let { number ->
@@ -83,7 +85,8 @@ class HomeViewModel : ViewModel(), DefaultHeader {
                     }.awaitAll()
                     uiDataList.onEachIndexed { index, item ->
                         item.imageUrl =
-                            imageUriList[index]?.sprites?.other?.officialArtwork?.imgUrl ?: ""
+                            pokemonPersonalDataList[index]?.sprites?.other?.officialArtwork?.imgUrl
+                                ?: ""
                     }
 
                     // 一覧に表示するポケモンの日本語名を取得
@@ -91,7 +94,11 @@ class HomeViewModel : ViewModel(), DefaultHeader {
                         val pokemonNumber = Uri.parse(item.url).lastPathSegment
                         async {
                             pokemonNumber?.let { number ->
-                                repository.getPokemonSpecies(number.toInt())
+                                val data = repository.getPokemonPersonalData(number.toInt())
+                                val speciesNumber = Uri.parse(data.species.url).lastPathSegment
+                                speciesNumber?.let { num ->
+                                    repository.getPokemonSpecies(num.toInt())
+                                }
                             }
                         }
                     }.awaitAll()
@@ -150,4 +157,3 @@ class HomeViewModel : ViewModel(), DefaultHeader {
         }
     }
 }
-

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/PokemonDetailViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/PokemonDetailViewModel.kt
@@ -1,8 +1,11 @@
 package com.example.pokebook.ui.viewModel
 
+import android.net.Uri
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.pokebook.model.PokemonSpecies
+import com.example.pokebook.model.StatType
 import com.example.pokebook.repository.DefaultPokemonDetailRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -19,57 +22,60 @@ class PokemonDetailViewModel : ViewModel() {
         MutableStateFlow(PokemonDetailScreenUiData())
     val conditionState = _conditionState.asStateFlow()
 
+    private lateinit var species: PokemonSpecies
+
     /**
-     *　ポケモンの種類に関する情報を取得
+     *　ポケモンの種類に関する情報を取得（番号検索）
      */
-    fun getPokemonSpecies(pokeId: Int) = viewModelScope.launch {
-        Log.d("test","詳細画面検索ポケモン名: $pokeId")
+    fun getPokemonSpeciesByNumber(pokeId: Int) = viewModelScope.launch {
         _uiState.emit(PokemonDetailUiState.Loading)
         runCatching {
-            repository.getPokemonSpecies(pokeId)
+            repository.getPokemonPersonalData(pokeId)
         }.onSuccess {
-            // ポケモン個体情報取得
-            val pokemonPersonalData = repository.getPokemonPersonalData(pokeId)
+            val speciesNumber = Uri.parse(it.species.url).lastPathSegment
 
+            speciesNumber?.let { num ->
+                // ポケモン特性を取得
+                species = repository.getPokemonSpecies(num.toInt())
+            }
             // 名前
-            val name = it.names.firstOrNull { names -> names.language.name == "ja" }?.name ?: ""
+            val name =
+                species.names.firstOrNull { names -> names.language.name == "ja" }?.name ?: ""
 
             // 説明
-            val description = it.flavorTextEntries.firstOrNull { flavorTextEntries ->
+            val description = species.flavorTextEntries.firstOrNull { flavorTextEntries ->
                 flavorTextEntries.language.name == "ja"
             }?.flavorText ?: ""
 
             // 分類
             val genus =
-                it.genera.firstOrNull { genera -> genera.language.name == "ja" }?.genus ?: ""
+                species.genera.firstOrNull { genera -> genera.language.name == "ja" }?.genus ?: ""
 
             // タイプ
             val type: MutableList<String> =
-                pokemonPersonalData.types.map { type -> type.type.name }.toMutableList()
+                it.types.map { type -> type.type.name }.toMutableList()
 
             // 画像
-            val imageUri = pokemonPersonalData.sprites.other.officialArtwork.imgUrl
+            val imageUri = it.sprites.other.officialArtwork.imgUrl
 
-            pokemonPersonalData.stats.onEach { stats ->
+            it.stats.onEach { stats ->
                 _conditionState.update { currentState ->
-
-                    // TODO enumで分岐したい
                     when (stats.stat.name) {
-                        "hp" -> {
+                        StatType.HP.type -> {
                             currentState.copy(
                                 hp = stats.baseStat
                             )
                         }
 
-                        "attack" -> currentState.copy(
+                        StatType.ATTACK.type -> currentState.copy(
                             attack = stats.baseStat
                         )
 
-                        "defense" -> currentState.copy(
+                        StatType.DEFENSE.type -> currentState.copy(
                             defense = stats.baseStat
                         )
 
-                        "speed" -> currentState.copy(
+                        StatType.SPEED.type -> currentState.copy(
                             speed = stats.baseStat
                         )
 
@@ -81,14 +87,87 @@ class PokemonDetailViewModel : ViewModel() {
             // id 日本語名　説明　属性
             _conditionState.update { currentState ->
                 currentState.copy(
-                    id = it.id,
+                    id = species.id,
                     name = name,
                     type = type,
                     description = description,
                     genus = genus,
                     imageUri = imageUri ?: "",
-                    height = pokemonPersonalData.height/10.0,
-                    weight = pokemonPersonalData.weight/10.0
+                    height = it.height / 10.0,
+                    weight = it.weight / 10.0
+                )
+            }
+            _uiState.emit(PokemonDetailUiState.Fetched)
+        }.onFailure {
+            Log.d("error", "e[getPokemonList]:$it")
+        }
+    }
+
+    /**
+     * ポケモンの種類に関する情報を取得（画像URLを引数で渡す）
+     */
+    fun getPokemonSpeciesByNumber(pokemonListUiData: PokemonListUiData) = viewModelScope.launch {
+        _uiState.emit(PokemonDetailUiState.Loading)
+        runCatching {
+            repository.getPokemonPersonalData(pokemonListUiData.id)
+        }.onSuccess {
+            val speciesNumber = Uri.parse(it.species.url).lastPathSegment
+            speciesNumber?.let { num ->
+                // ポケモン特性を取得
+                species = repository.getPokemonSpecies(num.toInt())
+            }
+
+            // 説明
+            val description = species.flavorTextEntries.firstOrNull { flavorTextEntries ->
+                flavorTextEntries.language.name == "ja"
+            }?.flavorText ?: ""
+
+            // 分類
+            val genus =
+                species.genera.firstOrNull { genera -> genera.language.name == "ja" }?.genus ?: ""
+
+            // タイプ
+            val type: MutableList<String> =
+                it.types.map { type -> type.type.name }.toMutableList()
+
+            // HP 攻撃　防御　スピード
+            it.stats.onEach { stats ->
+                _conditionState.update { currentState ->
+                    when (stats.stat.name) {
+                        StatType.HP.type -> {
+                            currentState.copy(
+                                hp = stats.baseStat
+                            )
+                        }
+
+                        StatType.ATTACK.type -> currentState.copy(
+                            attack = stats.baseStat
+                        )
+
+                        StatType.DEFENSE.type -> currentState.copy(
+                            defense = stats.baseStat
+                        )
+
+                        StatType.SPEED.type -> currentState.copy(
+                            speed = stats.baseStat
+                        )
+
+                        else -> currentState
+                    }
+                }
+            }
+
+            // id 日本語名　説明　属性
+            _conditionState.update { currentState ->
+                currentState.copy(
+                    id = pokemonListUiData.id,
+                    name = pokemonListUiData.displayName,
+                    type = type,
+                    description = description,
+                    genus = genus,
+                    imageUri = pokemonListUiData.imageUrl ?: "",
+                    height = it.height / 10.0,
+                    weight = it.weight / 10.0
                 )
             }
             _uiState.emit(PokemonDetailUiState.Fetched)

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/SearchViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/SearchViewModel.kt
@@ -101,9 +101,6 @@ class SearchViewModel : ViewModel(), DefaultHeader {
         // 未取得の場合のみ取得しにいく
         if (!displayUiDataList[pagePosition].isFetched) {
             _uiState.emit(SearchUiState.Loading)
-
-            Log.d("test","urlList: $urlList")
-
             urlList.onEach { url ->
                 val pokemonNumber = Uri.parse(url).lastPathSegment
                 async {


### PR DESCRIPTION
## 対応内容

* ポケモン詳細画面を叩く際の引数の取り方を変更

## レビュー観点

* 何ができるようになるのか？（あれば。無いなら「無し」でOK）
getPokemonPersonalDataで取得したURLが持つ個体Noを使ってpokemon-species APIを叩く処理に変更


## スクリーンショット

| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/a18926e0-049a-48d2-bd0b-ded407f1c8e8" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/a81f1ec2-b5f0-4970-a184-8f1a234314b3" width="200px"/>|

