### PR TITLE
特定条件でSEARCHタブ押下にてクラッシュする事象を修正

### DIFF
--- a/app/src/main/java/com/example/pokebook/ui/screen/BottomNavigationScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/BottomNavigationScreen.kt
@@ -167,9 +167,13 @@ fun BottomNavigationView() {
     val navController = rememberNavController()
     Scaffold(
         bottomBar = { BottomNavigationBar(navController) }
-    ) {
+    ) { innerPadding ->
         StatusBarColorSample()
-        NavigationHost(navController)
+        NavigationHost(
+            startDestination = BottomNavItems.Home.route,
+            navController = navController,
+            modifier = Modifier.padding(innerPadding)
+        )
     }
 }
 

--- a/app/src/main/java/com/example/pokebook/ui/screen/BottomNavigationScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/BottomNavigationScreen.kt
@@ -30,27 +30,6 @@ import com.example.pokebook.ui.viewModel.SearchViewModel
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
 /**
- * ボトムナビゲーション
- */
-sealed class BottomNavItems(
-    val route: String,
-    val name: String,
-    val icon: ImageVector
-) {
-    object Home : BottomNavItems("home", "HOME", Icons.Filled.Home)
-    object Search : BottomNavItems("search", "SEARCH", Icons.Filled.Search)
-    object Like : BottomNavItems("like", "LIKE", Icons.Filled.Star)
-    object Setting : BottomNavItems("setting", "SETTING", Icons.Filled.Settings)
-}
-
-val navItems = listOf(
-    BottomNavItems.Home,
-    BottomNavItems.Search,
-    BottomNavItems.Like,
-    BottomNavItems.Setting
-)
-
-/**
  * NavHost に宛先を設定する
  */
 @SuppressLint("ComposableDestinationInComposeScope")

--- a/app/src/main/java/com/example/pokebook/ui/screen/BottomNavigationScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/BottomNavigationScreen.kt
@@ -52,13 +52,11 @@ private fun NavigationHost(
         startDestination = startDestination,
         modifier = modifier
     ) {
-        // homeタブ
         homeGraph(
             navController = navController,
             homeViewModel = homeViewModel,
             pokemonDetailViewModel = pokemonDetailViewModel
         )
-
         searchGraph(
             navController = navController,
             searchViewModel = searchViewModel,
@@ -89,7 +87,7 @@ fun NavGraphBuilder.homeGraph(
             HomeScreen(
                 homeViewModel = homeViewModel,
                 pokemonDetailViewModel = pokemonDetailViewModel,
-                onClickCard = { navController.navigate("home/pokemonDetailScreen") }
+                onClickCard = { navController.navigate(HomeScreen.PokemonDetailScreen.route) }
             )
         }
         composable(HomeScreen.PokemonDetailScreen.route) {
@@ -118,16 +116,16 @@ fun NavGraphBuilder.searchGraph(
             SearchScreen(
                 searchViewModel = searchViewModel,
                 pokemonDetailViewModel = pokemonDetailViewModel,
-                onClickSearchPokemonName = { navController.navigate("search/pokemonDetailScreen") },
-                onClickSearchPokemonNumber = { navController.navigate("search/pokemonDetailScreen") },
-                onClickSearchTypeButton = { navController.navigate("search/pokemonListScreen") },
+                onClickSearchPokemonName = { navController.navigate(SearchScreen.PokemonDetailScreen.route) },
+                onClickSearchPokemonNumber = { navController.navigate(SearchScreen.PokemonDetailScreen.route) },
+                onClickSearchTypeButton = { navController.navigate(SearchScreen.PokemonListScreen.route) },
             )
         }
         composable(SearchScreen.PokemonListScreen.route) {
             SearchListScreen(
                 searchViewModel = searchViewModel,
                 pokemonDetailViewModel = pokemonDetailViewModel,
-                onClickCard = { navController.navigate("search/pokemonDetailScreen") },
+                onClickCard = { navController.navigate(SearchScreen.PokemonDetailScreen.route) },
                 onClickBackSearchScreen = { navController.navigateUp() }
             )
 

--- a/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
@@ -194,8 +194,6 @@ fun PokeList(
                 getPokemonSpecies = getPokemonSpecies
             )
         }
-        // 下部がボトムナビゲーションとかぶってしまった為
-        item { Spacer(modifier = Modifier.height(70.dp)) }
     }
 }
 

--- a/app/src/main/java/com/example/pokebook/ui/screen/NavigationRoutes.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/NavigationRoutes.kt
@@ -1,0 +1,29 @@
+package com.example.pokebook.ui.screen
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.ui.graphics.vector.ImageVector
+
+/**
+ * ボトムナビゲーション
+ */
+sealed class BottomNavItems(
+    val route: String,
+    val name: String,
+    val icon: ImageVector
+) {
+    object Home : BottomNavItems("home", "HOME", Icons.Filled.Home)
+    object Search : BottomNavItems("search", "SEARCH", Icons.Filled.Search)
+    object Like : BottomNavItems("like", "LIKE", Icons.Filled.Star)
+    object Setting : BottomNavItems("setting", "SETTING", Icons.Filled.Settings)
+}
+
+val navItems = listOf(
+    BottomNavItems.Home,
+    BottomNavItems.Search,
+    BottomNavItems.Like,
+    BottomNavItems.Setting
+)

--- a/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -25,14 +24,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -142,8 +139,6 @@ private fun PokemonDetailScreen(
                 modifier = modifier
                     .align(Alignment.CenterHorizontally)
             )
-            // 下部がボトムナビゲーションとかぶってしまった為
-            Spacer(modifier = Modifier.height(70.dp))
         }
     }
 }

--- a/app/src/main/java/com/example/pokebook/ui/screen/ScreenRoutes.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/ScreenRoutes.kt
@@ -1,0 +1,28 @@
+package com.example.pokebook.ui.screen
+
+/**
+ * HOMEタブ
+ */
+sealed class HomeScreen(val route: String) {
+    object PokemonListScreen : HomeScreen("home/pokemonListScreen")
+    object PokemonDetailScreen : HomeScreen("home/pokemonDetailScreen")
+}
+
+/**
+ * SEARCHタブ
+ */
+sealed class SearchScreen(val route: String) {
+    object SearchTopScreen : SearchScreen("search/searchScreen")
+    object PokemonListScreen : SearchScreen("search/pokemonListScreen")
+    object PokemonNotFound : SearchScreen("search/pokemonNotFound")
+    object PokemonDetailScreen : SearchScreen("search/pokemonDetailScreen")
+}
+
+/**
+ * LIKEタブ
+ */
+
+
+/**
+ * SETTINGタブ
+ */

--- a/app/src/main/java/com/example/pokebook/ui/screen/SearchListScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/SearchListScreen.kt
@@ -191,7 +191,6 @@ private fun PokeTypeList(
         columns = GridCells.Adaptive(minSize = 150.dp),
         modifier = Modifier
             .fillMaxSize()
-            .padding(bottom = 70.dp)
     ) {
         items(pokemonUiDataList) { listItem ->
             PokeTypeCard(


### PR DESCRIPTION
## 対応内容

* ナビゲーショングラフのネスト方法が誤っていたため修正
　→navControllerを各スコープで作成していたが、一つのnavControllerを引数で渡す処理に修正
　→navigation()を使ってナビゲーショングラフをネスト
* デスティネーションルートに関数流sealedクラスを作成
* innerPaddingを渡し、各画面における不要な画面サイズ調整に関する記載を削除


## スクリーンショット

| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/7e6b48e7-c542-4c62-bf58-53849d7acf5a" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/2f9158a6-af5d-462b-8a1c-62d136514bf1" width="200px"/>|