### PR TITLE
エラー時にエラーダイアログやエラー画面が出せるよう実装

### DIFF
--- a/app/src/main/java/com/example/pokebook/ui/screen/CommonScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/CommonScreen.kt
@@ -2,18 +2,19 @@ package com.example.pokebook.ui.screen
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.AlertDialog
 import androidx.compose.material.Button
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -22,8 +23,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -53,55 +56,31 @@ fun LoadingScreen(modifier: Modifier = Modifier) {
  * エラー画面
  */
 @Composable
-fun ErrorScreen(modifier: Modifier = Modifier) {
+fun <T> ErrorScreen(
+    consumeEvent: (T) -> Unit,
+    event: T,
+    modifier: Modifier = Modifier
+) {
     Box(
         contentAlignment = Alignment.Center,
-        modifier = modifier.fillMaxSize()
+        modifier = modifier
+            .background(androidx.compose.material3.MaterialTheme.colorScheme.background)
+            .fillMaxSize()
     ) {
-        Text(stringResource(R.string.loading_failed))
-    }
-}
-
-/**
- * 文字サイズの自動調整
- */
-@Composable
-fun AutoSizeableText(
-    text: String,
-    color: Color,
-    maxTextSize: Int = 50,
-    minTextSize: Int = 40,
-    modifier: Modifier
-) {
-    var textSize by remember { mutableStateOf(maxTextSize) }
-    val checked = remember(text) { mutableMapOf<Int, Boolean?>() }
-    var overflow by remember { mutableStateOf(TextOverflow.Clip) }
-
-    Text(
-        text = text,
-        color = color,
-        fontSize = textSize.sp,
-        maxLines = 1,
-        overflow = overflow,
-        modifier = modifier,
-        onTextLayout = {
-            if (it.hasVisualOverflow) {
-                checked[textSize] = true
-                if (textSize > minTextSize) {
-                    textSize -= 1
-                } else {
-                    overflow = TextOverflow.Ellipsis
+        AlertDialog(
+            onDismissRequest = { consumeEvent.invoke(event) },
+            confirmButton = {
+                TextButton(
+                    onClick = { consumeEvent.invoke(event) }
+                ) {
+                    Text(text = "閉じる")
                 }
-            } else {
-                checked[textSize] = false
-                if (textSize < maxTextSize) {
-                    if (checked[textSize + 1] == null) {
-                        textSize += 1
-                    }
-                }
+            },
+            text = {
+                Text("ポケモン取得エラー")
             }
-        }
-    )
+        )
+    }
 }
 
 /**
@@ -119,7 +98,7 @@ fun PokemonNotFound(
         verticalArrangement = Arrangement.Center
     ) {
         Text(
-            text = "該当するポケモンが存在しません",
+            text = stringResource(R.string.pokemon_not_found_text),
             color = androidx.compose.material3.MaterialTheme.colorScheme.onBackground,
             fontSize = 20.sp
         )
@@ -130,11 +109,106 @@ fun PokemonNotFound(
             shape = RoundedCornerShape(4.dp),
         ) {
             Text(
-                text = "検索TOPに戻る",
+                text = stringResource(R.string.back_screen_button_text),
                 modifier = Modifier
                     .wrapContentWidth()
                     .padding(vertical = 10.dp),
                 textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+/**
+ * ホームタブ取得エラー画面
+ */
+@Composable
+fun HomeResultError(
+    onClickRetryGetList: (Boolean) -> Unit,
+    isFirst: Boolean,
+) {
+    Column(
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .background(color = androidx.compose.material3.MaterialTheme.colorScheme.background)
+            .fillMaxSize()
+    ) {
+        Image(
+            imageVector = ImageVector.vectorResource(
+                id =
+                if (isSystemInDarkTheme()) {
+                    R.drawable.baseline_warning_amber_24_fillf
+                } else {
+                    R.drawable.baseline_warning_amber_24_fill0
+                }
+            ),
+            contentDescription = null,
+            modifier = Modifier
+                .padding(bottom = 10.dp)
+        )
+        Text(
+            text = stringResource(R.string.result_error_text),
+            color = androidx.compose.material3.MaterialTheme.colorScheme.onBackground,
+            modifier = Modifier
+                .padding(bottom = 10.dp)
+        )
+        Button(
+            onClick = { onClickRetryGetList.invoke(isFirst) },
+            shape = RoundedCornerShape(4.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.retry_button_text),
+                modifier = Modifier
+                    .wrapContentWidth(),
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+/**
+ * 取得エラー画面
+ */
+@Composable
+fun ResultError(
+    onClickBackSearchScreen: () -> Unit
+) {
+    Column(
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .background(color = androidx.compose.material3.MaterialTheme.colorScheme.background)
+            .fillMaxSize()
+    ) {
+        Image(
+            imageVector = ImageVector.vectorResource(
+                id =
+                if (isSystemInDarkTheme()) {
+                    R.drawable.baseline_warning_amber_24_fillf
+                } else {
+                    R.drawable.baseline_warning_amber_24_fill0
+                }
+            ),
+            contentDescription = null,
+            modifier = Modifier
+                .padding(bottom = 10.dp)
+        )
+        Text(
+            text = stringResource(R.string.result_error_text),
+            color = androidx.compose.material3.MaterialTheme.colorScheme.onBackground,
+            modifier = Modifier
+                .padding(bottom = 10.dp)
+        )
+        Button(
+            onClick = onClickBackSearchScreen,
+            shape = RoundedCornerShape(4.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.back_screen_button_text),
+                modifier = Modifier
+                    .wrapContentWidth(),
+                textAlign = TextAlign.Center,
             )
         }
     }

--- a/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
@@ -38,8 +38,10 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.example.pokebook.R
 import com.example.pokebook.ui.viewModel.Detail.PokemonDetailScreenUiData
+import com.example.pokebook.ui.viewModel.Detail.PokemonDetailUiEvent
 import com.example.pokebook.ui.viewModel.Detail.PokemonDetailUiState
 import com.example.pokebook.ui.viewModel.Detail.PokemonDetailViewModel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
 @Composable
@@ -49,6 +51,8 @@ fun PokemonDetailScreen(
 ) {
     PokemonDetailScreen(
         uiState = pokemonDetailViewModel.uiState,
+        uiEvent = pokemonDetailViewModel.uiEvent,
+        consumeEvent = pokemonDetailViewModel::processed,
         conditionState = pokemonDetailViewModel.conditionState,
         onClickBackButton = onClickBackButton
     )
@@ -58,10 +62,25 @@ fun PokemonDetailScreen(
 @Composable
 private fun PokemonDetailScreen(
     uiState: StateFlow<PokemonDetailUiState>,
+    uiEvent: Flow<PokemonDetailUiEvent?>,
+    consumeEvent:(PokemonDetailUiEvent)->Unit,
     conditionState: StateFlow<PokemonDetailScreenUiData>,
     onClickBackButton: () -> Unit,
 ) {
     val state by uiState.collectAsStateWithLifecycle()
+    val uiEvent by uiEvent.collectAsStateWithLifecycle(initialValue = null)
+
+    when(uiEvent) {
+        is PokemonDetailUiEvent.Error -> {
+            ErrorScreen(
+                consumeEvent = consumeEvent,
+                event = uiEvent as PokemonDetailUiEvent.Error
+            )
+        }
+
+        null -> {}
+    }
+
 
     when (state) {
         is PokemonDetailUiState.Fetched -> {
@@ -72,6 +91,13 @@ private fun PokemonDetailScreen(
         }
 
         PokemonDetailUiState.Loading -> LoadingScreen()
+
+        PokemonDetailUiState.ResultError -> {
+            ResultError(
+                onClickBackSearchScreen = onClickBackButton
+            )
+        }
+
         else -> {}
     }
 }

--- a/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
@@ -22,14 +22,19 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -303,5 +308,47 @@ private fun PokemonDetailScreenPreview() {
     PokemonDetailScreen(
         uiData = PokemonDetailScreenUiData(),
         onClickBackButton = {},
+    )
+}
+
+/**
+ * 文字サイズの自動調整
+ */
+@Composable
+fun AutoSizeableText(
+    text: String,
+    color: Color,
+    maxTextSize: Int = 50,
+    minTextSize: Int = 40,
+    modifier: Modifier
+) {
+    var textSize by remember { mutableStateOf(maxTextSize) }
+    val checked = remember(text) { mutableMapOf<Int, Boolean?>() }
+    var overflow by remember { mutableStateOf(TextOverflow.Clip) }
+
+    androidx.compose.material.Text(
+        text = text,
+        color = color,
+        fontSize = textSize.sp,
+        maxLines = 1,
+        overflow = overflow,
+        modifier = modifier,
+        onTextLayout = {
+            if (it.hasVisualOverflow) {
+                checked[textSize] = true
+                if (textSize > minTextSize) {
+                    textSize -= 1
+                } else {
+                    overflow = TextOverflow.Ellipsis
+                }
+            } else {
+                checked[textSize] = false
+                if (textSize < maxTextSize) {
+                    if (checked[textSize + 1] == null) {
+                        textSize += 1
+                    }
+                }
+            }
+        }
     )
 }

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailState.kt
@@ -1,5 +1,6 @@
 package com.example.pokebook.ui.viewModel.Detail
 
+import com.example.pokebook.ui.viewModel.Home.HomeUiState
 import java.util.UUID
 
 /**
@@ -9,6 +10,7 @@ sealed class PokemonDetailUiState {
     object Loading : PokemonDetailUiState()
     object Fetched : PokemonDetailUiState()
     object InitialState : PokemonDetailUiState()
+    object ResultError: PokemonDetailUiState()
 }
 
 

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Home/HomeState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Home/HomeState.kt
@@ -12,6 +12,7 @@ sealed class HomeUiState {
     ) : HomeUiState()
 
     object InitialState : HomeUiState()
+    object ResultError: HomeUiState()
 }
 
 /**
@@ -34,7 +35,7 @@ data class HomeScreenConditionState(
     val offset: String = "20",
     val previous: String = "",
     val currentNumberStart: String = "1",
-    val isFirst:Boolean = true
+    val isScrollTop:Boolean = true
 )
 
 /**

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Search/SearchState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Search/SearchState.kt
@@ -1,5 +1,6 @@
 package com.example.pokebook.ui.viewModel.Search
 
+import com.example.pokebook.ui.viewModel.Home.HomeUiState
 import com.example.pokebook.ui.viewModel.Home.PokemonListUiData
 import java.util.UUID
 
@@ -13,6 +14,7 @@ sealed class SearchUiState {
     ) : SearchUiState()
 
     object InitialState : SearchUiState()
+    object ResultError: SearchUiState()
 }
 
 data class SearchConditionState(

--- a/app/src/main/res/drawable/baseline_warning_amber_24_fill0.xml
+++ b/app/src/main/res/drawable/baseline_warning_amber_24_fill0.xml
@@ -1,0 +1,7 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,5.99L19.53,19H4.47L12,5.99M12,2L1,21h22L12,2L12,2z"/>
+    <path android:fillColor="@android:color/white" android:pathData="M13,16l-2,0l0,2l2,0z"/>
+    <path android:fillColor="@android:color/white" android:pathData="M13,10l-2,0l0,5l2,0z"/>
+</vector>

--- a/app/src/main/res/drawable/baseline_warning_amber_24_fillf.xml
+++ b/app/src/main/res/drawable/baseline_warning_amber_24_fillf.xml
@@ -1,0 +1,7 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,5.99L19.53,19H4.47L12,5.99M12,2L1,21h22L12,2L12,2z"/>
+    <path android:fillColor="@android:color/white" android:pathData="M13,16l-2,0l0,2l2,0z"/>
+    <path android:fillColor="@android:color/white" android:pathData="M13,10l-2,0l0,5l2,0z"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,7 +5,7 @@
     <string name="icon_like">like</string>
     <string name="icon_setting">setting</string>
     <string name="loading">loading</string>
-    <string name="loading_failed">Failed to load</string>
+    <string name="loading_failed">読み込みに失敗しました</string>
     <string name="header_title_displayed_number">#%s 〜 #%s</string>
     <string name="back_button">◀︎戻る︎</string>
     <string name="next_button">次へ ▶︎︎</string>
@@ -46,4 +46,8 @@
     <string name="header_title_search_list_1">「%s」の検索結果一覧</string>
     <string name="header_title_search_list_2">\n%d / %s ページ</string>
     <string name="header_title_search_list_loading">\nポケモン取得中</string>
+    <string name="result_error_text">通信に失敗し、結果を取得できませんでした。\n時間を置いてから再度読み込んで下さい。</string>
+    <string name="retry_button_text">再取得する</string>
+    <string name="pokemon_not_found_text">該当するポケモンが存在しません</string>
+    <string name="back_screen_button_text">前の画面に戻る</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,7 +46,7 @@
     <string name="header_title_search_list_1">「%s」の検索結果一覧</string>
     <string name="header_title_search_list_2">\n%d / %s ページ</string>
     <string name="header_title_search_list_loading">\nポケモン取得中</string>
-    <string name="result_error_text">通信に失敗し、結果を取得できませんでした。\n時間を置いてから再度読み込んで下さい。</string>
+    <string name="result_error_text">結果を取得できませんでした。\n時間を置いてから再度読み込んで下さい。</string>
     <string name="retry_button_text">再取得する</string>
     <string name="pokemon_not_found_text">該当するポケモンが存在しません</string>
     <string name="back_screen_button_text">前の画面に戻る</string>


### PR DESCRIPTION

## 対応内容

* Homeタブ、Searchタブ、詳細画面それぞれにエラー時にダイアログとエラー画面が表示できるよう実装
* 必要なリソースを追加


* どのような動作確認を行ったのか？　結果はどうか？

## スクリーンショット

| dialog | 一覧取得エラー画面 | 共通のエラー画面 |
|--------|-------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/a963dfdf-e840-43cf-82aa-1bdb5e3a8166" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/63b20d63-ebd8-4ebe-a7c8-ab56b9e245b6" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/bdae3dfa-8877-47dd-98b6-944ff78abfdc" width="200px"/>
