### PR TITLE
likeたぶで画面が更新されない事象を修正

### DIFF
--- a/app/src/main/java/com/example/pokebook/ui/screen/DefaultHeaderScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/DefaultHeaderScreen.kt
@@ -1,13 +1,16 @@
 package com.example.pokebook.ui.screen
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
@@ -16,7 +19,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -28,11 +33,11 @@ import com.example.pokebook.R
 @Composable
 fun DefaultHeader(
     title: String,
-    displayPage: Int = 0,
-    maxPage: String = "",
     updateButtonStates: (Boolean, Boolean) -> Unit = { _, _ -> },
     onClickNext: () -> Unit = {},
     onClickBack: () -> Unit = {},
+    onClickBackButton: () -> Unit = {},
+    isSearch: Boolean = false
 ) {
     Column(
         modifier = Modifier
@@ -41,6 +46,18 @@ fun DefaultHeader(
             .fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        if (isSearch) {
+            Image(
+                imageVector = ImageVector.vectorResource(
+                    id = if (isSystemInDarkTheme()) R.drawable.arrow_back_fillf else R.drawable.arrow_back_fill0
+                ),
+                contentDescription = null,
+                modifier = Modifier
+                    .size(30.dp)
+                    .align(Alignment.Start)
+                    .clickable { onClickBackButton.invoke() }
+            )
+        }
         Text(
             text = title,
             color = MaterialTheme.colorScheme.onBackground,

--- a/app/src/main/java/com/example/pokebook/ui/screen/LikeEntryScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/LikeEntryScreen.kt
@@ -94,6 +94,7 @@ private fun LikeEntryBody(
     getAllList: () -> Unit,
     getPokemonSpecies: (PokemonListUiData) -> Unit
 ) {
+    getAllList.invoke()
     val state by uiState.collectAsStateWithLifecycle()
     val uiEvent by uiEventState.collectAsStateWithLifecycle(initialValue = null)
 

--- a/app/src/main/java/com/example/pokebook/ui/screen/LikeEntryScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/LikeEntryScreen.kt
@@ -110,12 +110,11 @@ private fun LikeEntryBody(
     }
 
     when (state) {
+        is LikeUiState.Loading -> {
+            LoadingScreen()
+        }
         is LikeUiState.Fetched -> {
-            if ((state as LikeUiState.Fetched).uiDataList.isEmpty()) {
-                PokemonNotFound(
-                    onClickBackSearchScreen = onClickBackButton
-                )
-            } else {
+            if ((state as LikeUiState.Fetched).uiDataList.isNotEmpty()) {
                 LikeScreen(
                     likeList = (state as LikeUiState.Fetched).uiDataList,
                     onClickCard = onClickCard,
@@ -124,13 +123,12 @@ private fun LikeEntryBody(
                     getAllList = getAllList,
                     getPokemonSpecies = getPokemonSpecies
                 )
+            } else {
+                PokemonNotFound(
+                    onClickBackSearchScreen = onClickBackButton
+                )
             }
         }
-
-        is LikeUiState.Loading -> {
-            LoadingScreen()
-        }
-
         is LikeUiState.ResultError -> {
             ResultError(onClickBackSearchScreen = onClickBackButton)
         }

--- a/app/src/main/java/com/example/pokebook/ui/screen/Navigation/BottomNavigationScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/Navigation/BottomNavigationScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination

--- a/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
@@ -50,6 +50,7 @@ import com.example.pokebook.ui.viewModel.Detail.PokemonDetailUiState
 import com.example.pokebook.ui.viewModel.Detail.PokemonDetailViewModel
 import com.example.pokebook.ui.viewModel.Like.LikeDetails
 import com.example.pokebook.ui.viewModel.Like.LikeEntryViewModel
+import com.example.pokebook.ui.viewModel.Like.LikeUiState
 import com.example.pokebook.ui.viewModel.Like.toLikeDetails
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
@@ -85,7 +86,7 @@ private fun PokemonDetailScreen(
     updateIsLike: (Boolean, Int) -> Unit,
     saveLike: suspend (LikeDetails) -> Unit,
     deleteLike: suspend (LikeDetails) -> Unit,
-    getAllList:()->Unit
+    getAllList: () -> Unit
 ) {
     val state by uiState.collectAsStateWithLifecycle()
     val uiEvent by uiEvent.collectAsStateWithLifecycle(initialValue = null)
@@ -133,7 +134,7 @@ private fun PokemonDetailScreen(
     updateIsLike: (Boolean, Int) -> Unit,
     saveLike: suspend (LikeDetails) -> Unit,
     deleteLike: suspend (LikeDetails) -> Unit,
-    getAllList : () ->Unit,
+    getAllList: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -151,7 +152,9 @@ private fun PokemonDetailScreen(
             contentDescription = null,
             modifier = Modifier
                 .align(Alignment.Start)
-                .clickable { onClickBackButton.invoke() }
+                .clickable {
+                    onClickBackButton.invoke()
+                }
         )
         TitleImage(
             pokemon = uiData,
@@ -208,7 +211,7 @@ private fun TitleImage(
     updateIsLike: (Boolean, Int) -> Unit,
     deleteLike: suspend (LikeDetails) -> Unit,
     saveLike: suspend (LikeDetails) -> Unit,
-    getAllList:()->Unit
+    getAllList: () -> Unit
 ) {
     Card(
         modifier = Modifier
@@ -245,7 +248,6 @@ private fun TitleImage(
                                 saveLike.invoke(pokemon.toLikeDetails())
                             }
                         }
-                        getAllList.invoke()
                         updateIsLike.invoke(!pokemon.isLike, pokemon.pokemonNumber)
                     }
             )

--- a/app/src/main/java/com/example/pokebook/ui/screen/SearchListScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/SearchListScreen.kt
@@ -55,7 +55,7 @@ fun SearchListScreen(
 ) {
     SearchListScreen(
         uiState = searchViewModel.uiState,
-        uiEvent = searchViewModel.uiEvent,
+        uiStateEvent = searchViewModel.uiEvent,
         consumeEvent = searchViewModel::processed,
         conditionState = searchViewModel.conditionState,
         onClickBack = searchViewModel::onClickBack,
@@ -64,7 +64,8 @@ fun SearchListScreen(
         updateButtonStates = searchViewModel::updateButtonStates,
         updateIsFirst = searchViewModel::updateIsFirst,
         getPokemonSpecies = pokemonDetailViewModel::getPokemonSpeciesByUiData,
-        onClickBackSearchScreen = onClickBackSearchScreen
+        onClickBackSearchScreen = onClickBackSearchScreen,
+        onClickBackButton = onClickBackSearchScreen
     )
 }
 
@@ -72,7 +73,7 @@ fun SearchListScreen(
 @Composable
 private fun SearchListScreen(
     uiState: StateFlow<SearchUiState>,
-    uiEvent: Flow<SearchUiEvent?>,
+    uiStateEvent: Flow<SearchUiEvent?>,
     consumeEvent: (SearchUiEvent) -> Unit,
     conditionState: StateFlow<SearchConditionState>,
     onClickBack: () -> Unit,
@@ -81,13 +82,12 @@ private fun SearchListScreen(
     updateButtonStates: (Boolean, Boolean) -> Unit,
     updateIsFirst: (Boolean) -> Unit,
     getPokemonSpecies: (PokemonListUiData) -> Unit,
-    onClickBackSearchScreen: () -> Unit
+    onClickBackSearchScreen: () -> Unit,
+    onClickBackButton:()->Unit
 ) {
     val state by uiState.collectAsStateWithLifecycle()
-    val uiEvent by uiEvent.collectAsStateWithLifecycle(initialValue = null)
-    val lazyGridState = rememberLazyGridState()
+    val uiEvent by uiStateEvent.collectAsStateWithLifecycle(initialValue = null)
     val searchWord = conditionState.value.pokemonTypeName
-    val coroutineScope = rememberCoroutineScope()
 
     when(uiEvent) {
         is SearchUiEvent.Error -> {
@@ -113,15 +113,13 @@ private fun SearchListScreen(
                     searchWord = searchWord,
                     pagePosition = conditionState.value.pagePosition.plus(1),
                     maxPage = conditionState.value.maxPage,
-                    displayPage = conditionState.value.pagePosition,
                     onClickBack = onClickBack,
                     onClickNext = onClickNext,
                     onClickCard = onClickCard,
                     updateButtonStates = updateButtonStates,
                     updateIsFirst = updateIsFirst,
                     getPokemonSpecies = getPokemonSpecies,
-                    lazyGridState = lazyGridState,
-                    coroutineScope = coroutineScope
+                    onClickBackSearchScreen = onClickBackSearchScreen
                 )
             }
         }
@@ -133,8 +131,7 @@ private fun SearchListScreen(
                         stringResource(R.string.header_title_search_list_1),
                         searchWord
                     ) + stringResource(id = R.string.header_title_search_list_loading),
-                    displayPage = conditionState.value.pagePosition,
-                    maxPage = conditionState.value.maxPage
+                    onClickBackButton=onClickBackButton
                 )
                 LoadingScreen()
             }
@@ -157,20 +154,21 @@ private fun SearchListScreen(
     searchWord: String,
     pagePosition: Int,
     maxPage: String,
-    displayPage: Int,
     onClickBack: () -> Unit,
     onClickNext: () -> Unit,
     onClickCard: () -> Unit,
     updateButtonStates: (Boolean, Boolean) -> Unit,
     updateIsFirst: (Boolean) -> Unit,
     getPokemonSpecies: (PokemonListUiData) -> Unit,
-    lazyGridState: LazyGridState,
-    coroutineScope: CoroutineScope
+    onClickBackSearchScreen:()->Unit,
 ) {
     Column(
         modifier = Modifier
             .background(MaterialTheme.colorScheme.background),
     ) {
+        val lazyGridState = rememberLazyGridState()
+        val coroutineScope = rememberCoroutineScope()
+
         DefaultHeader(
             title = String.format(
                 stringResource(R.string.header_title_search_list_1),
@@ -184,10 +182,11 @@ private fun SearchListScreen(
                     maxPage
                 )
             },
-            displayPage = displayPage,
             updateButtonStates = updateButtonStates,
             onClickBack = onClickBack,
             onClickNext = onClickNext,
+            onClickBackButton = onClickBackSearchScreen,
+            isSearch = true
         )
         PokeTypeList(
             pokemonUiDataList = pokemonUiDataList,

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Like/LikeEntryViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Like/LikeEntryViewModel.kt
@@ -40,11 +40,7 @@ class LikeEntryViewModel(private val likesRepository: LikesRepository) : ViewMod
 
     // 表示用リスト
     private val uiDataList = mutableListOf<LikeDetails>()
-
-    init {
-        getAllList()
-    }
-
+    
     /**
      * Room データベースにアイテムを挿入
      */


### PR DESCRIPTION

## 対応内容

* like画面が開く時にlikeリストを更新する処理を追加
* 不要な引数を削除、フォーマットの調整
* 検索一覧で戻るボタンが出るよう変更

## スクリーンショット

| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/aed6a8d1-3db9-415e-a4b7-20a537c103c3" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/258b9dc7-fba6-4a27-aeeb-5c894d5e9614" width="200px"/>|

