### PR TITLE
ライクアイコンが連動しない事象を修正

### DIFF
--- a/app/src/main/java/com/example/pokebook/data/like/Like.kt
+++ b/app/src/main/java/com/example/pokebook/data/like/Like.kt
@@ -15,15 +15,5 @@ data class Like(
     val pokemonNumber:Int = 0,
     val name: String,
     val displayName: String,
-    val description: String,
-    val genus: String,
-//    @TypeConverters()
-//    val type: List<String>,
-    val hp: Int,
-    val attack: Int,
-    val defense: Int,
-    val speed: Int,
     val imageUrl: String,
-    val height: Double,
-    val weight: Double
 )

--- a/app/src/main/java/com/example/pokebook/data/like/LikeDao.kt
+++ b/app/src/main/java/com/example/pokebook/data/like/LikeDao.kt
@@ -7,6 +7,7 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
 import com.example.pokebook.data.like.Like
+import com.example.pokebook.data.pokemonData.PokemonData
 
 @Dao
 interface LikeDao {
@@ -24,4 +25,7 @@ interface LikeDao {
 
     @Query("SELECT * from likes ORDER BY name ASC")
     fun getAllItems(): List<Like>
+
+    @Query("SELECT * FROM likes WHERE pokemonNumber = :pokemonNumber")
+    fun searchByName(pokemonNumber: Int): Like
 }

--- a/app/src/main/java/com/example/pokebook/data/like/LikesRepository.kt
+++ b/app/src/main/java/com/example/pokebook/data/like/LikesRepository.kt
@@ -22,7 +22,12 @@ interface LikesRepository {
     suspend fun deleteItem(like: Like)
 
     /**
-     * データソースの項目を更新
+     * データ・ソースの項目を更新
      */
     suspend fun updateItem(like: Like)
+
+    /**
+     * データ・ソースから項目をキーワードの項目を検索
+     */
+    suspend fun searchPokemonByName(pokemonNumber: Int):Like
 }

--- a/app/src/main/java/com/example/pokebook/data/like/OfflineLikesRepository.kt
+++ b/app/src/main/java/com/example/pokebook/data/like/OfflineLikesRepository.kt
@@ -12,4 +12,5 @@ class OfflineLikesRepository(private val likeDao: LikeDao) : LikesRepository {
     override suspend fun deleteItem(like: Like) = likeDao.delete(like)
 
     override suspend fun updateItem(like: Like) = likeDao.update(like)
+    override suspend fun searchPokemonByName(pokemonNumber: Int): Like  = likeDao.searchByName(pokemonNumber)
 }

--- a/app/src/main/java/com/example/pokebook/ui/AppViewModelProvider.kt
+++ b/app/src/main/java/com/example/pokebook/ui/AppViewModelProvider.kt
@@ -33,7 +33,8 @@ object AppViewModelProvider {
         initializer {
             PokemonDetailViewModel(
                 pokemonApplication().container.pokemonDetailRepository,
-                pokemonApplication().container.pokemonDataRepository
+                pokemonApplication().container.pokemonDataRepository,
+                pokemonApplication().container.likesRepository
             )
         }
     }

--- a/app/src/main/java/com/example/pokebook/ui/screen/LikeEntryScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/LikeEntryScreen.kt
@@ -236,9 +236,9 @@ private fun LikePokeCard(
                             .clickable {
                                 coroutineScope.launch {
                                     deleteLike.invoke(pokemon)
-                                    getAllList.invoke()
                                 }
                                 updateIsLike.invoke(!pokemon.isLike, pokemon.pokemonNumber)
+                                getAllList.invoke()
                             }
                     )
                 }

--- a/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
@@ -1,6 +1,7 @@
 package com.example.pokebook.ui.screen
 
 import android.annotation.SuppressLint
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -68,7 +69,7 @@ fun PokemonDetailScreen(
         updateIsLike = pokemonDetailViewModel::updateIsLike,
         saveLike = likeEntryViewModel::saveLike,
         deleteLike = likeEntryViewModel::deleteLike,
-        getAllList = likeEntryViewModel::getAllList
+        checkIfRoomLike = pokemonDetailViewModel::checkIfRoomLike
     )
 }
 
@@ -83,7 +84,7 @@ private fun PokemonDetailScreen(
     updateIsLike: (Boolean, Int) -> Unit,
     saveLike: suspend (LikeDetails) -> Unit,
     deleteLike: suspend (LikeDetails) -> Unit,
-    getAllList: () -> Unit
+    checkIfRoomLike: suspend (Int) -> Unit
 ) {
     val state by uiState.collectAsStateWithLifecycle()
     val uiEvent by uiEvent.collectAsStateWithLifecycle(initialValue = null)
@@ -108,7 +109,7 @@ private fun PokemonDetailScreen(
                 updateIsLike = updateIsLike,
                 saveLike = saveLike,
                 deleteLike = deleteLike,
-                getAllList = getAllList
+                checkIfRoomLike = checkIfRoomLike
             )
         }
 
@@ -139,7 +140,7 @@ private fun PokemonDetailScreen(
     updateIsLike: (Boolean, Int) -> Unit,
     saveLike: suspend (LikeDetails) -> Unit,
     deleteLike: suspend (LikeDetails) -> Unit,
-    getAllList: () -> Unit,
+    checkIfRoomLike: suspend (Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -167,7 +168,7 @@ private fun PokemonDetailScreen(
             updateIsLike = updateIsLike,
             deleteLike = deleteLike,
             saveLike = saveLike,
-            getAllList = getAllList
+            checkIfRoomLike = checkIfRoomLike
         )
         Column(
             verticalArrangement = Arrangement.spacedBy(20.dp),
@@ -209,6 +210,7 @@ private fun PokemonDetailScreen(
     }
 }
 
+@SuppressLint("CoroutineCreationDuringComposition")
 @Composable
 private fun TitleImage(
     type: String,
@@ -216,7 +218,7 @@ private fun TitleImage(
     updateIsLike: (Boolean, Int) -> Unit,
     deleteLike: suspend (LikeDetails) -> Unit,
     saveLike: suspend (LikeDetails) -> Unit,
-    getAllList: () -> Unit
+    checkIfRoomLike: suspend (Int) -> Unit
 ) {
     Card(
         modifier = Modifier
@@ -237,6 +239,9 @@ private fun TitleImage(
                     )
                 )
         ) {
+            coroutineScope.launch {
+                checkIfRoomLike.invoke(pokemon.pokemonNumber)
+            }
             Image(
                 imageVector = ImageVector.vectorResource(
                     id = if (pokemon.isLike) R.drawable.favorite_fill else R.drawable.favorite_border

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailState.kt
@@ -7,12 +7,15 @@ import java.util.UUID
  */
 sealed class PokemonDetailUiState {
     object Loading : PokemonDetailUiState()
-    object Fetched : PokemonDetailUiState()
+    data class Fetched(val detailUiCondition:DetailUiCondition ) : PokemonDetailUiState()
     object InitialState : PokemonDetailUiState()
-    object ResultError: PokemonDetailUiState()
-    object SearchError: PokemonDetailUiState()
+    object ResultError : PokemonDetailUiState()
+    object SearchError : PokemonDetailUiState()
 }
 
+data class DetailUiCondition(
+    val isLike:Boolean = false
+)
 
 /**
  *　ID
@@ -40,7 +43,7 @@ data class PokemonDetailScreenUiData(
     val imageUri: String = "",
     val height: Double = 0.0,
     val weight: Double = 0.0,
-    val isLike:Boolean = false
+    val isLike: Boolean = false
 )
 
 /**

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Like/LikeState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Like/LikeState.kt
@@ -59,16 +59,7 @@ fun LikeDetails.toLike(): Like = Like(
     pokemonNumber = pokemonNumber,
     name = name,
     displayName = displayName,
-    description = description,
-    genus = genus,
-//    type = type,
-    hp = hp,
-    attack = attack,
-    defense = defense,
-    speed = speed,
     imageUrl = imageUrl,
-    height = height,
-    weight = weight
 )
 
 
@@ -114,16 +105,7 @@ fun List<Like>.toPokemonListUiDataList(): MutableList<LikeDetails> {
                 pokemonNumber = like.pokemonNumber,
                 name = like.name,
                 displayName = like.displayName,
-                description = like.description,
-                genus = like.genus,
-//                type =like.,
-                hp = like.hp,
-                attack = like.attack,
-                defense = like.defense,
-                speed = like.speed,
                 imageUrl = like.imageUrl,
-                height = like.height,
-                weight = like.weight,
                 isLike = true
             )
         }


### PR DESCRIPTION
## 対応内容

* 詳細画面のlikeアイコン表示判定のフラグはlikesテーブルにデータがあるかないかで判定する処理に変更
* likeアイコン押下時、データベースの保存、コンディションの変更に加え、表示判定に使っているフラグの更新も行うよう処理を追加した
* likesテーブルの不要なパラメーターを削除


## スクリーンショット

| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/e0f6ee29-f862-43e9-90c4-c3e132505419" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/e879504c-f920-413a-b307-228bfa004986" width="200px"/>|

