### PR TITLE
likeタブのちらつきや、端末による挙動不安定な事象を修正

### DIFF
--- a/app/src/main/java/com/example/pokebook/ui/screen/LikeEntryScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/LikeEntryScreen.kt
@@ -91,7 +91,6 @@ private fun LikeEntryBody(
     getAllList: () -> Unit,
     getPokemonSpecies: (PokemonListUiData) -> Unit
 ) {
-    getAllList.invoke()
     val state by uiState.collectAsStateWithLifecycle()
     val uiEvent by uiEventState.collectAsStateWithLifecycle(initialValue = null)
 
@@ -112,7 +111,11 @@ private fun LikeEntryBody(
         }
 
         is LikeUiState.Fetched -> {
-            if ((state as LikeUiState.Fetched).uiDataList.isNotEmpty()) {
+            if ((state as LikeUiState.Fetched).uiDataList.isEmpty()) {
+                PokemonNotFound(
+                    onClickBackSearchScreen = onClickBackButton
+                )
+            } else {
                 LikeScreen(
                     likeList = (state as LikeUiState.Fetched).uiDataList,
                     onClickCard = onClickCard,
@@ -120,10 +123,6 @@ private fun LikeEntryBody(
                     deleteLike = deleteLike,
                     getAllList = getAllList,
                     getPokemonSpecies = getPokemonSpecies
-                )
-            } else {
-                PokemonNotFound(
-                    onClickBackSearchScreen = onClickBackButton
                 )
             }
         }
@@ -236,9 +235,9 @@ private fun LikePokeCard(
                             .clickable {
                                 coroutineScope.launch {
                                     deleteLike.invoke(pokemon)
+                                    updateIsLike.invoke(!pokemon.isLike, pokemon.pokemonNumber)
+                                    getAllList.invoke()
                                 }
-                                updateIsLike.invoke(!pokemon.isLike, pokemon.pokemonNumber)
-                                getAllList.invoke()
                             }
                     )
                 }

--- a/app/src/main/java/com/example/pokebook/ui/screen/Navigation/BottomNavigationScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/Navigation/BottomNavigationScreen.kt
@@ -169,6 +169,7 @@ fun NavGraphBuilder.likeGraph(
         route = BottomNavItems.Like.route
     ) {
         composable(LikeScreen.LikeListScreen.route) {
+            likeEntryViewModel.getAllList()
             LikeEntryScreen(
                 onClickCard = { navController.navigate(LikeScreen.LikeDetailScreen.route) },
                 onClickBackButton = { navController.navigateUp() },

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Like/LikeEntryViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Like/LikeEntryViewModel.kt
@@ -39,8 +39,8 @@ class LikeEntryViewModel(private val likesRepository: LikesRepository) : ViewMod
     }
 
     // 表示用リスト
-    private val uiDataList = mutableListOf<LikeDetails>()
-    
+    private var uiDataList = mutableListOf<LikeDetails>()
+
     /**
      * Room データベースにアイテムを挿入
      */
@@ -63,14 +63,12 @@ class LikeEntryViewModel(private val likesRepository: LikesRepository) : ViewMod
      * データベースから全てのアイテムを取得
      */
     fun getAllList() = viewModelScope.launch {
-        uiDataList.clear()
         _uiState.emit(LikeUiState.Loading)
-
         runCatching {
             withContext(Dispatchers.IO) {
-                likesRepository.getAllItemsStream().apply {
-                    uiDataList += this.toPokemonListUiDataList()
-                }
+                val stream = likesRepository.getAllItemsStream()
+                val dataList = stream.toList()
+                uiDataList = dataList.toPokemonListUiDataList()
             }
         }
             .onSuccess {
@@ -84,10 +82,10 @@ class LikeEntryViewModel(private val likesRepository: LikesRepository) : ViewMod
     }
 
     /**
-     * Likeフラグを更新
+     * 一覧表示を更新する
      */
-    fun updateIsLike(isLike: Boolean, pokemonNumber: Int) {
-        uiDataList.map { data ->
+    fun updateIsLike(isLike: Boolean, pokemonNumber: Int) = viewModelScope.launch {
+        uiDataList.forEach { data ->
             if (data.pokemonNumber == pokemonNumber) {
                 data.isLike = isLike
             }


### PR DESCRIPTION

## 対応内容

* like一覧のisLikeステータス更新の際、mapを使っていたがforEachに変更
* DB検索後のlist生成の際に、待ち合わせできるようtoList()を使用するよう変更
* likeタブ押下時に likeEntryViewModel::getAllListを叩くよう修正


## スクリーンショット

| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/fbf7ba33-d86e-459b-afb5-456d03c24761" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/f44162b6-bd31-4be1-930e-4e4114e84c6e" width="200px"/>|

