### PR TITLE
一覧取得時の性能改善

### DIFF
--- a/app/src/main/java/com/example/pokebook/data/pokemonData/OfflinePokemonDataRepository.kt
+++ b/app/src/main/java/com/example/pokebook/data/pokemonData/OfflinePokemonDataRepository.kt
@@ -16,4 +16,13 @@ class OfflinePokemonDataRepository(private val pokemonDataDao: PokemonDataDao) :
     override suspend fun updateItem(pokemon: PokemonData) = pokemonDataDao.update(pokemon)
     override suspend fun searchPokemonByKeyword(keyword: String): PokemonData =
         pokemonDataDao.searchByJapaneseName(keyword)
+
+    override suspend fun getAllItemsBetweenIds(startId: Int, endId: Int): List<PokemonData> =
+        pokemonDataDao.getAllItemsBetweenIds(startId, endId).apply {
+            Log.d("test","startId:$startId,endId:$endId")
+        }
+
+    override suspend fun updatePokemonData(id: Int, imageUrl: String,speciesNumber:String?) {
+        pokemonDataDao.updatePokemonData(id, imageUrl,speciesNumber)
+    }
 }

--- a/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonData.kt
+++ b/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonData.kt
@@ -1,7 +1,12 @@
 package com.example.pokebook.data.pokemonData
 
+import android.net.Uri
 import androidx.room.Entity
+import androidx.room.Ignore
 import androidx.room.PrimaryKey
+import com.example.pokebook.json.PokemonDataByJson
+import com.example.pokebook.model.PokemonPersonalData
+import com.example.pokebook.model.PokemonSpecies
 
 /**
  * 初回起動時にjsonファイルから取得するためのエンティティ
@@ -11,11 +16,27 @@ import androidx.room.PrimaryKey
 data class PokemonData(
     @PrimaryKey(autoGenerate = true)
     val id: Int = 0,
-    val englishName: String,
-    val japaneseName:String,
+    val englishName: String? = "",
+    val japaneseName: String = "",
 //    val type:List<String>
-    val hp: Int,
-    val Attack: Int,
-    val Defense: Int,
-    val Speed: Int
+    val hp: Int? = 0,
+    val attack: Int? = 0,
+    val defense: Int? = 0,
+    val speed: Int? = 0,
+    val imageUrl: String? = "",
+    val speciesNumber: String? = ""
+)
+
+/**
+ * PokemonPersonalData -> PokemonData
+ */
+fun PokemonPersonalData.pokemonPersonalDataToPokemonData(): PokemonData = PokemonData(
+    imageUrl = this.sprites.other.officialArtwork.imgUrl ?: "",
+    speciesNumber = if (!this.species.url.isNullOrEmpty()) Uri.parse(this.species.url).lastPathSegment else ""
+)
+
+/**
+ * PokemonSpecies -> PokemonData
+ */
+fun PokemonSpecies.convertSpeciesToPokemonData(): PokemonData = PokemonData(
 )

--- a/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonDataDao.kt
+++ b/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonDataDao.kt
@@ -25,6 +25,15 @@ interface PokemonDataDao {
     @Query("SELECT * from pokemonData ORDER BY japaneseName ASC")
     fun getAllItems(): List<PokemonData>
 
+    // japaneseName完全一致の検索
     @Query("SELECT * FROM pokemonData WHERE japaneseName = :keyword")
     fun searchByJapaneseName(keyword: String): PokemonData
+
+    // 指定された範囲のデータの検索
+    @Query("SELECT id,imageUrl,japaneseName FROM pokemonData WHERE id BETWEEN :startId AND :endId")
+    fun getAllItemsBetweenIds(startId: Int, endId: Int): List<PokemonData>
+
+    //　指定したIDのimageUrlにデータを挿入
+    @Query("UPDATE pokemonData SET imageUrl = :imageUrl,speciesNumber = :speciesNumber WHERE id = :id")
+    suspend fun updatePokemonData(id: Int, imageUrl: String, speciesNumber: String?)
 }

--- a/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonDataRepository.kt
+++ b/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonDataRepository.kt
@@ -30,4 +30,14 @@ interface PokemonDataRepository {
      * 指定されたjapaneseNameを検索
      */
     suspend fun searchPokemonByKeyword(keyword: String): PokemonData
+
+    /**
+     * 指定された範囲のデータの検索
+     */
+    suspend fun getAllItemsBetweenIds(startId: Int, endId: Int): List<PokemonData>
+
+    /**
+     * 指定したIDのimageUrl、speciesNumberにデータを挿入
+     */
+    suspend fun updatePokemonData(id: Int, imageUrl: String, speciesNumber: String?)
 }

--- a/app/src/main/java/com/example/pokebook/json/PokemonDataByJson.kt
+++ b/app/src/main/java/com/example/pokebook/json/PokemonDataByJson.kt
@@ -42,7 +42,7 @@ fun PokemonDataByJson.toPokemonData(): PokemonData = PokemonData(
     japaneseName = this.name.japanese,
 //    typy = this.type,
     hp = this.base.hp,
-    Attack = this.base.attack,
-    Defense = this.base.defense,
-    Speed = this.base.speed
+    attack = this.base.attack,
+    defense = this.base.defense,
+    speed = this.base.speed
 )

--- a/app/src/main/java/com/example/pokebook/ui/AppViewModelProvider.kt
+++ b/app/src/main/java/com/example/pokebook/ui/AppViewModelProvider.kt
@@ -27,7 +27,8 @@ object AppViewModelProvider {
         }
         initializer {
             HomeViewModel(
-                pokemonApplication().container.homeRepository
+                pokemonApplication().container.homeRepository,
+                pokemonApplication().container.pokemonDataRepository
             )
         }
         initializer {

--- a/app/src/main/java/com/example/pokebook/ui/screen/CommonScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/CommonScreen.kt
@@ -121,7 +121,7 @@ fun PokemonNotFound(
  */
 @Composable
 fun HomeResultError(
-    onClickRetryGetList: (Boolean) -> Unit,
+    onClickRetryGetList: () -> Unit,
     isFirst: Boolean,
 ) {
     Column(
@@ -151,7 +151,7 @@ fun HomeResultError(
                 .padding(bottom = 10.dp)
         )
         Button(
-            onClick = { onClickRetryGetList.invoke(isFirst) },
+            onClick = { onClickRetryGetList.invoke() },
             shape = RoundedCornerShape(4.dp),
         ) {
             Text(

--- a/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
@@ -77,7 +77,7 @@ private fun HomeScreen(
     onClickBack: () -> Unit,
     onClickCard: (Int) -> Unit,
     updateIsFirst: (Boolean) -> Unit,
-    onClickRetryGetList: (Boolean) -> Unit
+    onClickRetryGetList: () -> Unit
 ) {
     val state by uiState.collectAsStateWithLifecycle()
     val uiEvent by uiEvent.collectAsStateWithLifecycle(initialValue = null)
@@ -98,8 +98,8 @@ private fun HomeScreen(
     when (state) {
         is HomeUiState.Fetched -> {
             PokeList(
-                currentNumberStart = homeUiConditionState.value.currentNumberStart,
-                currentNumberEnd = homeUiConditionState.value.offset,
+                startId = homeUiConditionState.value.pagePosition * 20 + 1,
+                endId = homeUiConditionState.value.pagePosition * 20 + 20,
                 pokemonUiDataList = (state as HomeUiState.Fetched).uiDataList,
                 isFirst = homeUiConditionState.value.isScrollTop,
                 onClickNext = onClickNext,
@@ -116,8 +116,8 @@ private fun HomeScreen(
                 DefaultHeader(
                     title = String.format(
                         stringResource(id = R.string.header_title_displayed_number),
-                        homeUiConditionState.value.currentNumberStart,
-                        homeUiConditionState.value.offset
+                        homeUiConditionState.value.pagePosition * 20 + 1,
+                        homeUiConditionState.value.pagePosition * 20 + 20
                     ),
                     onClickNext = onClickNext,
                     onClickBack = onClickBack,
@@ -139,8 +139,8 @@ private fun HomeScreen(
 
 @Composable
 private fun PokeList(
-    currentNumberStart: String,
-    currentNumberEnd: String,
+    startId: Int,
+    endId: Int,
     pokemonUiDataList: List<PokemonListUiData>,
     isFirst: Boolean,
     onClickNext: () -> Unit,
@@ -157,8 +157,8 @@ private fun PokeList(
         DefaultHeader(
             title = String.format(
                 stringResource(id = R.string.header_title_displayed_number),
-                currentNumberStart,
-                currentNumberEnd
+                startId,
+                endId
             ),
             onClickNext = onClickNext,
             onClickBack = onClickBack

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Home/HomeState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Home/HomeState.kt
@@ -31,11 +31,9 @@ data class PokemonListUiData(
 )
 
 data class HomeScreenConditionState(
-    val count: Int = 0,
-    val offset: String = "20",
-    val previous: String = "",
-    val currentNumberStart: String = "1",
-    val isScrollTop:Boolean = true
+    val isScrollTop:Boolean = true,
+    val pagePosition:Int = 0,
+    val speciesNumber:String? = ""
 )
 
 /**

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Home/HomeViewModel.kt
@@ -76,21 +76,23 @@ class HomeViewModel(
                                     repository.getPokemonPersonalData(index.id)
                                         .pokemonPersonalDataToPokemonData()
 
-                                // imageUrlを取得したらDBに保存する
-                                pokemonPersonalData.imageUrl?.let{
-                                    pokemonDataRepository.updatePokemonData(
-                                        id = index.id,
-                                        imageUrl = pokemonPersonalData.imageUrl,
-                                        speciesNumber = pokemonPersonalData.speciesNumber
-                                    )
-                                }
+                                async{
+                                    // imageUrlを取得したらDBに保存する
+                                    pokemonPersonalData.imageUrl?.let{
+                                        pokemonDataRepository.updatePokemonData(
+                                            id = index.id,
+                                            imageUrl = pokemonPersonalData.imageUrl,
+                                            speciesNumber = pokemonPersonalData.speciesNumber
+                                        )
+                                    }
 
-                                // 表示用リストに追加する
-                                uiDataList += PokemonListUiData(
-                                    pokemonNumber = index.id,
-                                    displayName = index.japaneseName,
-                                    imageUrl = pokemonPersonalData.imageUrl
-                                )
+                                    // 表示用リストに追加する
+                                    uiDataList += PokemonListUiData(
+                                        pokemonNumber = index.id,
+                                        displayName = index.japaneseName,
+                                        imageUrl = pokemonPersonalData.imageUrl
+                                    )
+                                }.await()
 
                                 // HomeScreenConditionStateを更新
                                 _conditionState.update { currentState ->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
     <string name="icon_setting">setting</string>
     <string name="loading">loading</string>
     <string name="loading_failed">読み込みに失敗しました</string>
-    <string name="header_title_displayed_number">#%s 〜 #%s</string>
+    <string name="header_title_displayed_number">#%s - #%s</string>
     <string name="back_button">◀︎戻る︎</string>
     <string name="next_button">次へ ▶︎︎</string>
     <string name="pokemon_genus">分類：%s</string>


### PR DESCRIPTION
## 対応内容

* 一覧取得の際、初回で取り込んだDB情報を参照して、DBに必要情報が揃っている場合はDBの情報を表示し、揃ってない場合はAPIを叩いてDBに保存するという処理に変更
* 表示場所をページ数で管理するよう変更
* DBの特定データを検索、DBの特定データを更新する処理を追加

