### PR TITLE
一覧Headerの戻る・次へボタンの制御を実装

### DIFF
--- a/app/src/main/java/com/example/pokebook/ui/screen/DefaultHeaderScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/DefaultHeaderScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -32,7 +33,9 @@ import com.example.pokebook.R
  */
 @Composable
 fun DefaultHeader(
+    pagePosition: Int,
     title: String,
+    maxPage: String = "500",
     updateButtonStates: (Boolean, Boolean) -> Unit = { _, _ -> },
     onClickNext: () -> Unit = {},
     onClickBack: () -> Unit = {},
@@ -72,53 +75,62 @@ fun DefaultHeader(
             modifier = Modifier
                 .padding(vertical = 6.dp)
         ) {
-            Box(
-                modifier = Modifier
-                    .weight(1F)
-                    .wrapContentHeight()
-                    .clickable {
-                        updateButtonStates.invoke(true, false)
-                        onClickBack.invoke()
-                    },
-                contentAlignment = Alignment.CenterEnd
-            ) {
-                Text(
-                    text = stringResource(R.string.back_button),
-                    color = MaterialTheme.colorScheme.onBackground,
+            if (pagePosition != 0) {
+                Box(
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .border(
-                            width = 1.dp,
-                            color = Color.DarkGray,
-                            shape = RoundedCornerShape(20.dp)
-                        )
-                        .padding(4.dp),
-                    textAlign = TextAlign.Center
-                )
+                        .weight(1F)
+                        .wrapContentHeight()
+                        .clickable {
+                            updateButtonStates.invoke(true, false)
+                            onClickBack.invoke()
+                        },
+                    contentAlignment = Alignment.CenterEnd
+                ) {
+
+                    Text(
+                        text = stringResource(R.string.back_button),
+                        color = MaterialTheme.colorScheme.onBackground,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .border(
+                                width = 1.dp,
+                                color = Color.DarkGray,
+                                shape = RoundedCornerShape(20.dp)
+                            )
+                            .padding(4.dp),
+                        textAlign = TextAlign.Center
+                    )
+                }
+            } else {
+                Spacer(modifier = Modifier.weight(1F))
             }
-            Box(
-                modifier = Modifier
-                    .weight(1F)
-                    .wrapContentHeight()
-                    .clickable {
-                        updateButtonStates.invoke(false, true)
-                        onClickNext.invoke()
-                    },
-                contentAlignment = Alignment.CenterEnd
-            ) {
-                Text(
-                    text = stringResource(R.string.next_button),
-                    color = MaterialTheme.colorScheme.onBackground,
+            if (pagePosition == maxPage.toInt().minus(1)) {
+                Spacer(modifier = Modifier.weight(1F))
+            } else {
+                Box(
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .border(
-                            width = 1.dp,
-                            color = Color.DarkGray,
-                            shape = RoundedCornerShape(20.dp)
-                        )
-                        .padding(4.dp),
-                    textAlign = TextAlign.Center
-                )
+                        .weight(1F)
+                        .wrapContentHeight()
+                        .clickable {
+                            updateButtonStates.invoke(false, true)
+                            onClickNext.invoke()
+                        },
+                    contentAlignment = Alignment.CenterEnd
+                ) {
+                    Text(
+                        text = stringResource(R.string.next_button),
+                        color = MaterialTheme.colorScheme.onBackground,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .border(
+                                width = 1.dp,
+                                color = Color.DarkGray,
+                                shape = RoundedCornerShape(20.dp)
+                            )
+                            .padding(4.dp),
+                        textAlign = TextAlign.Center
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -98,8 +99,7 @@ private fun HomeScreen(
     when (state) {
         is HomeUiState.Fetched -> {
             PokeList(
-                startId = homeUiConditionState.value.pagePosition * 20 + 1,
-                endId = homeUiConditionState.value.pagePosition * 20 + 20,
+                pagePosition = homeUiConditionState.value.pagePosition,
                 pokemonUiDataList = (state as HomeUiState.Fetched).uiDataList,
                 isFirst = homeUiConditionState.value.isScrollTop,
                 onClickNext = onClickNext,
@@ -114,6 +114,7 @@ private fun HomeScreen(
         HomeUiState.Loading -> {
             Column {
                 DefaultHeader(
+                    pagePosition = homeUiConditionState.value.pagePosition,
                     title = String.format(
                         stringResource(id = R.string.header_title_displayed_number),
                         homeUiConditionState.value.pagePosition * 20 + 1,
@@ -139,8 +140,7 @@ private fun HomeScreen(
 
 @Composable
 private fun PokeList(
-    startId: Int,
-    endId: Int,
+    pagePosition: Int,
     pokemonUiDataList: List<PokemonListUiData>,
     isFirst: Boolean,
     onClickNext: () -> Unit,
@@ -152,13 +152,15 @@ private fun PokeList(
 ) {
     Column(
         modifier = Modifier
+            .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
     ) {
         DefaultHeader(
+            pagePosition = pagePosition,
             title = String.format(
                 stringResource(id = R.string.header_title_displayed_number),
-                startId,
-                endId
+                pagePosition * 20 + 1,
+                pagePosition * 20 + 20,
             ),
             onClickNext = onClickNext,
             onClickBack = onClickBack

--- a/app/src/main/java/com/example/pokebook/ui/screen/SearchListScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/SearchListScreen.kt
@@ -108,7 +108,7 @@ private fun SearchListScreen(
                     pokemonUiDataList = (state as SearchUiState.Fetched).searchList,
                     isFirst = conditionState.value.isFirst,
                     searchWord = searchWord,
-                    pagePosition = conditionState.value.pagePosition.plus(1),
+                    pagePosition = conditionState.value.pagePosition,
                     maxPage = conditionState.value.maxPage,
                     onClickBack = onClickBack,
                     onClickNext = onClickNext,
@@ -123,6 +123,7 @@ private fun SearchListScreen(
         SearchUiState.Loading -> {
             Column {
                 DefaultHeader(
+                    pagePosition = conditionState.value.pagePosition,
                     title = String.format(
                         stringResource(R.string.header_title_search_list_1),
                         searchWord
@@ -166,6 +167,7 @@ private fun SearchListScreen(
         val coroutineScope = rememberCoroutineScope()
 
         DefaultHeader(
+            pagePosition = pagePosition,
             title = String.format(
                 stringResource(R.string.header_title_search_list_1),
                 searchWord
@@ -174,10 +176,11 @@ private fun SearchListScreen(
             } else {
                 String.format(
                     stringResource(R.string.header_title_search_list_2),
-                    pagePosition,
+                    pagePosition.plus(1),
                     maxPage
                 )
             },
+            maxPage = maxPage,
             updateButtonStates = updateButtonStates,
             onClickBack = onClickBack,
             onClickNext = onClickNext,


### PR DESCRIPTION
## 対応内容

*pagePositionを見て、戻るボタンつ次へボタンを制御


## スクリーンショット
＜戻る＞
| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/0a3398c9-fd1a-4762-9921-fd96f24dca9d" width="200px!"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/1415dfc4-284e-425a-b34d-5596d807a76d" width="200px"/>|


＜次へ＞
| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/bf216859-dd8e-4f79-b2b8-ed5a2e30ec56" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/0bf2496a-fcbc-4ef2-b9f5-92519fc53168" width="200px"/>|
