### PR TITLE
詳細画面表示時のロジックを変更

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -89,6 +89,7 @@ dependencies {
     implementation "androidx.room:room-runtime:2.5.0"
     implementation "androidx.room:room-ktx:2.5.0"
     kapt "androidx.room:room-compiler:2.5.0"
+    annotationProcessor "androidx.room:room-compiler:2.5.2"
     // splashscreen
     implementation "androidx.core:core-splashscreen:1.0.0-alpha01"
 }

--- a/app/src/main/java/com/example/pokebook/data/PokemonDatabase.kt
+++ b/app/src/main/java/com/example/pokebook/data/PokemonDatabase.kt
@@ -4,12 +4,16 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.TypeConverter
+import androidx.room.TypeConverters
 import com.example.pokebook.data.like.Like
 import com.example.pokebook.data.like.LikeDao
 import com.example.pokebook.data.pokemonData.PokemonData
 import com.example.pokebook.data.pokemonData.PokemonDataDao
+import com.example.pokebook.data.pokemonData.StringListTypeConverter
 
 @Database(entities = [Like::class, PokemonData::class ], version = 1, exportSchema = false)
+@TypeConverters(StringListTypeConverter::class)
 abstract class PokemonDatabase : RoomDatabase() {
     abstract fun likeDao(): LikeDao
     abstract fun pokemonDataDao(): PokemonDataDao

--- a/app/src/main/java/com/example/pokebook/data/pokemonData/OfflinePokemonDataRepository.kt
+++ b/app/src/main/java/com/example/pokebook/data/pokemonData/OfflinePokemonDataRepository.kt
@@ -9,7 +9,8 @@ class OfflinePokemonDataRepository(private val pokemonDataDao: PokemonDataDao) :
     PokemonDataRepository {
     override fun getAllItemsStream(): List<PokemonData> = pokemonDataDao.getAllItems()
 
-    override suspend fun insertItem(pokemonList: List<PokemonData>) = pokemonDataDao.insert(pokemonList)
+    override suspend fun insertItem(pokemonList: List<PokemonData>) =
+        pokemonDataDao.insert(pokemonList)
 
     override suspend fun deleteItem(pokemon: PokemonData) = pokemonDataDao.delete(pokemon)
 
@@ -20,7 +21,43 @@ class OfflinePokemonDataRepository(private val pokemonDataDao: PokemonDataDao) :
     override suspend fun getAllItemsBetweenIds(startId: Int, endId: Int): List<PokemonData> =
         pokemonDataDao.getAllItemsBetweenIds(startId, endId)
 
-    override suspend fun updatePokemonData(id: Int, imageUrl: String,speciesNumber:String?) {
-        pokemonDataDao.updatePokemonData(id, imageUrl,speciesNumber)
-    }
+    override suspend fun updatePokemonData(
+        id: Int,
+        imageUrl: String,
+        speciesNumber: String?
+    ) = pokemonDataDao.updatePokemonData(
+        id = id,
+        imageUrl = imageUrl,
+        speciesNumber = speciesNumber
+    )
+
+    override suspend fun updatePokemonAllData(
+        id: Int?,
+        englishName: String?,
+        japaneseName: String?,
+        description: String?,
+        hp: Int?,
+        attack: Int?,
+        defense: Int?,
+        speed: Int?,
+        imageUrl: String?,
+        genus: String?,
+        type: List<String>?,
+        speciesNumber: String?
+    ) = pokemonDataDao.updatePokemonAllData(
+        id = id,
+        englishName = englishName,
+        japaneseName = japaneseName,
+        description = description,
+        hp = hp,
+        attack = attack,
+        defense = defense,
+        speed = speed,
+        imageUrl = imageUrl,
+        genus = genus,
+        type = type,
+        speciesNumber = speciesNumber
+    )
+
+    override suspend fun searchById(id: Int): PokemonData = pokemonDataDao.searchById(id)
 }

--- a/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonData.kt
+++ b/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonData.kt
@@ -20,6 +20,8 @@ data class PokemonData(
     val id: Int = 0,
     val englishName: String? = "",
     val japaneseName: String = "",
+    val genus: String? = "",
+    val description: String? = "",
     val type: List<String>? = emptyList(),
     val hp: Int? = 0,
     val attack: Int? = 0,

--- a/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonData.kt
+++ b/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonData.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import androidx.room.Entity
 import androidx.room.Ignore
 import androidx.room.PrimaryKey
+import androidx.room.TypeConverters
 import com.example.pokebook.json.PokemonDataByJson
 import com.example.pokebook.model.PokemonPersonalData
 import com.example.pokebook.model.PokemonSpecies
@@ -13,12 +14,13 @@ import com.example.pokebook.model.PokemonSpecies
  * データベーステーブル
  */
 @Entity(tableName = "pokemonData")
+@TypeConverters(StringListTypeConverter::class)
 data class PokemonData(
     @PrimaryKey(autoGenerate = true)
     val id: Int = 0,
     val englishName: String? = "",
     val japaneseName: String = "",
-//    val type:List<String>
+    val type: List<String>? = emptyList(),
     val hp: Int? = 0,
     val attack: Int? = 0,
     val defense: Int? = 0,

--- a/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonDataDao.kt
+++ b/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonDataDao.kt
@@ -5,10 +5,12 @@ import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.TypeConverters
 import androidx.room.Update
 import com.example.pokebook.data.pokemonData.PokemonData
 
 @Dao
+@TypeConverters(StringListTypeConverter::class)
 interface PokemonDataDao {
     //挿入
     @Insert(onConflict = OnConflictStrategy.IGNORE)

--- a/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonDataDao.kt
+++ b/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonDataDao.kt
@@ -31,11 +31,32 @@ interface PokemonDataDao {
     @Query("SELECT * FROM pokemonData WHERE japaneseName = :keyword")
     fun searchByJapaneseName(keyword: String): PokemonData
 
+    // id完全一致の検索
+    @Query("SELECT * FROM pokemonData WHERE id = :id")
+    fun searchById(id: Int): PokemonData
+
     // 指定された範囲のデータの検索
     @Query("SELECT id,imageUrl,japaneseName FROM pokemonData WHERE id BETWEEN :startId AND :endId")
     fun getAllItemsBetweenIds(startId: Int, endId: Int): List<PokemonData>
 
-    //　指定したIDのimageUrlにデータを挿入
+    //　指定したIDのimageUrlとspeciesNumberにデータを挿入
     @Query("UPDATE pokemonData SET imageUrl = :imageUrl,speciesNumber = :speciesNumber WHERE id = :id")
     suspend fun updatePokemonData(id: Int, imageUrl: String, speciesNumber: String?)
+
+    // 指定したIDの必要なカラムを更新
+    @Query("UPDATE pokemonData SET englishName = :englishName, japaneseName = :japaneseName, description = :description,hp = :hp, attack = :attack, defense = :defense, speed = :speed, imageUrl = :imageUrl,speciesNumber = :speciesNumber,genus=:genus,type=:type WHERE id = :id")
+    suspend fun updatePokemonAllData(
+        id: Int? = null,
+        englishName: String? = null,
+        japaneseName: String? = null,
+        description: String? = null,
+        hp: Int? = null,
+        attack: Int? = null,
+        defense: Int? = null,
+        speed: Int? = null,
+        imageUrl: String? = null,
+        genus: String?,
+        type: List<String>?,
+        speciesNumber: String?
+    )
 }

--- a/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonDataRepository.kt
+++ b/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonDataRepository.kt
@@ -39,5 +39,33 @@ interface PokemonDataRepository {
     /**
      * 指定したIDのimageUrl、speciesNumberにデータを挿入
      */
-    suspend fun updatePokemonData(id: Int, imageUrl: String, speciesNumber: String?)
+    suspend fun updatePokemonData(
+        id: Int,
+        imageUrl: String,
+        speciesNumber: String? = null
+    )
+
+    /**
+     * 指定したIDの必要なカラムを更新
+     */
+    suspend fun updatePokemonAllData(
+        id: Int?=null,
+        englishName: String? = null,
+        japaneseName: String? = null,
+        description: String? = null,
+        hp: Int? = null,
+        attack: Int? = null,
+        defense: Int? = null,
+        speed: Int? = null,
+        imageUrl: String? =null,
+        genus: String? = null,
+        type: List<String>? = null,
+        speciesNumber: String? = null
+    )
+
+
+    /**
+     * id完全一致の検索
+     */
+    suspend fun searchById(id: Int): PokemonData
 }

--- a/app/src/main/java/com/example/pokebook/data/pokemonData/StringListTypeConverter.kt
+++ b/app/src/main/java/com/example/pokebook/data/pokemonData/StringListTypeConverter.kt
@@ -1,0 +1,61 @@
+package com.example.pokebook.data.pokemonData
+
+import android.util.JsonReader
+import android.util.JsonWriter
+import androidx.room.TypeConverter
+import java.io.IOException
+import java.io.StringReader
+import java.io.StringWriter
+
+
+class StringListTypeConverter {
+    @TypeConverter
+    fun fromStringList(strings: List<String>?): String? {
+        if (strings == null) {
+            return null
+        }
+
+        val result = StringWriter()
+        val json = JsonWriter(result)
+
+        try {
+            json.beginArray()
+
+            strings.forEach {
+                json.value(it)
+            }
+
+            json.endArray()
+            json.close()
+        } catch (e: IOException) {
+            return null
+        }
+
+        return result.toString()
+    }
+
+    @TypeConverter
+    fun toStringList(strings: String?): List<String>? {
+        if (strings == null) {
+            return null
+        }
+
+        val reader = StringReader(strings)
+        val json = JsonReader(reader)
+        val result = mutableListOf<String>()
+
+        try {
+            json.beginArray()
+
+            while (json.hasNext()) {
+                result.add(json.nextString())
+            }
+
+            json.endArray()
+        } catch (e: IOException) {
+            return null
+        }
+
+        return result
+    }
+}

--- a/app/src/main/java/com/example/pokebook/model/PokemonPersonalData.kt
+++ b/app/src/main/java/com/example/pokebook/model/PokemonPersonalData.kt
@@ -9,11 +9,12 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class PokemonPersonalData(
+    val id: Int,
     val species: Species,
     val sprites: Sprites,
     val stats: List<Stats>,
     val types: List<Types>,
-    val height:Int,
+    val height: Int,
     val weight: Int
 )
 
@@ -43,7 +44,7 @@ data class Species(
 @Serializable
 data class Stats(
     @SerialName("base_stat")
-    val baseStat:Int,
+    val baseStat: Int,
     val stat: Stat
 )
 
@@ -107,7 +108,7 @@ data class Genera(
     val language: Language
 )
 
-enum class StatType(val type: String){
+enum class StatType(val type: String) {
     HP("hp"),
     ATTACK("attack"),
     DEFENSE("defense"),

--- a/app/src/main/java/com/example/pokebook/ui/AppViewModelProvider.kt
+++ b/app/src/main/java/com/example/pokebook/ui/AppViewModelProvider.kt
@@ -41,7 +41,8 @@ object AppViewModelProvider {
             PokemonDetailViewModel(
                 pokemonApplication().container.pokemonDetailRepository,
                 pokemonApplication().container.pokemonDataRepository,
-                pokemonApplication().container.likesRepository
+                pokemonApplication().container.likesRepository,
+                pokemonApplication().container.pokemonDataRepository
             )
         }
     }

--- a/app/src/main/java/com/example/pokebook/ui/screen/Navigation/BottomNavigationScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/Navigation/BottomNavigationScreen.kt
@@ -49,7 +49,6 @@ private fun NavigationHost(
     navController: NavHostController = rememberNavController(),
     searchViewModel: SearchViewModel = viewModel(factory = AppViewModelProvider.Factory),
     homeViewModel: HomeViewModel = viewModel(factory = AppViewModelProvider.Factory),
-    pokemonDetailViewModel: PokemonDetailViewModel = viewModel(factory = AppViewModelProvider.Factory),
     likeEntryViewModel: LikeEntryViewModel = viewModel(factory = AppViewModelProvider.Factory),
     @SuppressLint("ModifierParameter") modifier: Modifier = Modifier
 ) {
@@ -61,18 +60,15 @@ private fun NavigationHost(
         homeGraph(
             navController = navController,
             homeViewModel = homeViewModel,
-            pokemonDetailViewModel = pokemonDetailViewModel,
             likeEntryViewModel = likeEntryViewModel
         )
         searchGraph(
             navController = navController,
             searchViewModel = searchViewModel,
-            pokemonDetailViewModel = pokemonDetailViewModel,
             likeEntryViewModel = likeEntryViewModel
         )
         likeGraph(
             navController = navController,
-            pokemonDetailViewModel = pokemonDetailViewModel,
             likeEntryViewModel = likeEntryViewModel
         )
 
@@ -88,7 +84,6 @@ private fun NavigationHost(
 fun NavGraphBuilder.homeGraph(
     navController: NavController,
     homeViewModel: HomeViewModel,
-    pokemonDetailViewModel: PokemonDetailViewModel,
     likeEntryViewModel: LikeEntryViewModel
 ) {
     navigation(
@@ -111,9 +106,8 @@ fun NavGraphBuilder.homeGraph(
             )
         ) { backStackEntry ->
             val pokemonNumber = backStackEntry.arguments?.getInt("pokemonNumber") ?: 0
-            pokemonDetailViewModel.getPokemonSpeciesById(pokemonNumber)
             PokemonDetailScreen(
-                pokemonDetailViewModel = pokemonDetailViewModel,
+                pokemonNumber = pokemonNumber,
                 likeEntryViewModel = likeEntryViewModel,
                 onClickBackButton = { navController.navigateUp() }
             )
@@ -127,7 +121,6 @@ fun NavGraphBuilder.homeGraph(
 fun NavGraphBuilder.searchGraph(
     navController: NavController,
     searchViewModel: SearchViewModel,
-    pokemonDetailViewModel: PokemonDetailViewModel,
     likeEntryViewModel: LikeEntryViewModel
 ) {
     navigation(
@@ -167,9 +160,8 @@ fun NavGraphBuilder.searchGraph(
             )
         ) { backStackEntry ->
             val pokemonName = backStackEntry.arguments?.getString("pokemonName") ?: ""
-            pokemonDetailViewModel.getPokemonSpeciesByName(pokemonName)
             PokemonDetailScreen(
-                pokemonDetailViewModel = pokemonDetailViewModel,
+                pokemonName = pokemonName,
                 likeEntryViewModel = likeEntryViewModel,
                 onClickBackButton = { navController.navigateUp() }
             )
@@ -181,9 +173,8 @@ fun NavGraphBuilder.searchGraph(
             )
         ) { backStackEntry ->
             val pokemonNumber = backStackEntry.arguments?.getInt("pokemonNumber") ?: 0
-            pokemonDetailViewModel.getPokemonSpeciesById(pokemonNumber)
             PokemonDetailScreen(
-                pokemonDetailViewModel = pokemonDetailViewModel,
+                pokemonNumber = pokemonNumber,
                 likeEntryViewModel = likeEntryViewModel,
                 onClickBackButton = { navController.navigateUp() }
             )
@@ -196,7 +187,6 @@ fun NavGraphBuilder.searchGraph(
  */
 fun NavGraphBuilder.likeGraph(
     navController: NavController,
-    pokemonDetailViewModel: PokemonDetailViewModel,
     likeEntryViewModel: LikeEntryViewModel
 ) {
     navigation(
@@ -220,9 +210,8 @@ fun NavGraphBuilder.likeGraph(
             )
         ) { backStackEntry ->
             val pokemonNumber = backStackEntry.arguments?.getInt("pokemonNumber") ?: 0
-            pokemonDetailViewModel.getPokemonSpeciesById(pokemonNumber)
             PokemonDetailScreen(
-                pokemonDetailViewModel = pokemonDetailViewModel,
+                pokemonNumber = pokemonNumber,
                 likeEntryViewModel = likeEntryViewModel,
                 onClickBackButton = { navController.navigateUp() }
             )

--- a/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
@@ -40,9 +40,11 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.example.pokebook.R
+import com.example.pokebook.ui.AppViewModelProvider
 import com.example.pokebook.ui.viewModel.Detail.PokemonDetailScreenUiData
 import com.example.pokebook.ui.viewModel.Detail.PokemonDetailUiEvent
 import com.example.pokebook.ui.viewModel.Detail.PokemonDetailUiState
@@ -56,10 +58,20 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun PokemonDetailScreen(
+    pokemonNumber: Int? = null,
+    pokemonName: String? = null,
     likeEntryViewModel: LikeEntryViewModel,
-    pokemonDetailViewModel: PokemonDetailViewModel,
+    pokemonDetailViewModel: PokemonDetailViewModel = viewModel(factory = AppViewModelProvider.Factory),
     onClickBackButton: () -> Unit
 ) {
+    if (pokemonNumber != null) {
+        pokemonDetailViewModel.getPokemonSpeciesById(pokemonNumber)
+    } else if (pokemonName != null) {
+        pokemonDetailViewModel.getPokemonSpeciesByName(pokemonName)
+    } else {
+        // 何もしない
+    }
+
     PokemonDetailScreen(
         uiState = pokemonDetailViewModel.uiState,
         uiEvent = pokemonDetailViewModel.uiEvent,
@@ -182,7 +194,7 @@ private fun PokemonDetailScreen(
                 text = String.format(
                     stringResource(id = R.string.pokemon_name),
                     uiData.pokemonNumber,
-                    uiData.name
+                    uiData.japaneseName
                 ),
                 color = MaterialTheme.colorScheme.onBackground,
                 modifier = modifier

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailState.kt
@@ -7,14 +7,14 @@ import java.util.UUID
  */
 sealed class PokemonDetailUiState {
     object Loading : PokemonDetailUiState()
-    data class Fetched(val detailUiCondition:DetailUiCondition ) : PokemonDetailUiState()
+    data class Fetched(val detailUiCondition: DetailUiCondition) : PokemonDetailUiState()
     object InitialState : PokemonDetailUiState()
     object ResultError : PokemonDetailUiState()
     object SearchError : PokemonDetailUiState()
 }
 
 data class DetailUiCondition(
-    val isLike:Boolean = false
+    val isLike: Boolean = false
 )
 
 /**
@@ -32,7 +32,8 @@ data class DetailUiCondition(
  */
 data class PokemonDetailScreenUiData(
     val pokemonNumber: Int = 0,
-    val name: String = "",
+    val englishName: String = "",
+    val japaneseName: String = "",
     val description: String = "",
     val genus: String = "",
     val type: List<String> = emptyList(),
@@ -43,7 +44,8 @@ data class PokemonDetailScreenUiData(
     val imageUri: String = "",
     val height: Double = 0.0,
     val weight: Double = 0.0,
-    val isLike: Boolean = false
+    val isLike: Boolean = false,
+    val speciesNumber: String = ""
 )
 
 /**

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailViewModel.kt
@@ -5,11 +5,14 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.pokebook.data.like.LikesRepository
+import com.example.pokebook.data.pokemonData.PokemonData
 import com.example.pokebook.data.pokemonData.PokemonDataRepository
+import com.example.pokebook.model.PokemonPersonalData
 import com.example.pokebook.model.PokemonSpecies
 import com.example.pokebook.model.StatType
 import com.example.pokebook.repository.PokemonDetailRepository
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -17,11 +20,13 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlin.reflect.typeOf
 
 class PokemonDetailViewModel(
     private val detailRepository: PokemonDetailRepository,
     private val dataRepository: PokemonDataRepository,
-    private val likesRepository: LikesRepository
+    private val likesRepository: LikesRepository,
+    private val pokemonDataRepository: PokemonDataRepository
 ) : ViewModel() {
     private var _uiState: MutableStateFlow<PokemonDetailUiState> =
         MutableStateFlow(PokemonDetailUiState.InitialState)
@@ -45,86 +50,179 @@ class PokemonDetailViewModel(
         _uiEvent.emit(_uiEvent.value.filterNot { it == event })
     }
 
-
-    private lateinit var species: PokemonSpecies
-
     /**
      *　ポケモンの種類に関する情報を取得（番号検索）
      */
     fun getPokemonSpeciesById(pokeId: Int) = viewModelScope.launch {
         _uiState.emit(PokemonDetailUiState.Loading)
         runCatching {
-            detailRepository.getPokemonPersonalData(pokeId)
-        }.onSuccess {
-            val speciesNumber = Uri.parse(it.species.url).lastPathSegment
+            withContext(Dispatchers.IO) {
+                // DBを検索
+                val roomResult = pokemonDataRepository.searchById(pokeId)
 
-            speciesNumber?.let { num ->
-                // ポケモン特性を取得
-                species = detailRepository.getPokemonSpecies(num.toInt())
-            }
-            // 名前
-            val name =
-                species.names.firstOrNull { names -> names.language.name == "ja" }?.name ?: ""
+                // DBに[description]がない場合
+                if (roomResult.description.isNullOrEmpty()) {
+                    val apiResult = detailRepository.getPokemonPersonalData(pokeId)
+                    val speciesNumber = Uri.parse(apiResult.species.url).lastPathSegment
 
-            // 説明
-            val description = species.flavorTextEntries.firstOrNull { flavorTextEntries ->
-                flavorTextEntries.language.name == "ja"
-            }?.flavorText ?: ""
-
-            // 分類
-            val genus =
-                species.genera.firstOrNull { genera -> genera.language.name == "ja" }?.genus ?: ""
-
-            // タイプ
-            val type: MutableList<String> =
-                it.types.map { type -> type.type.name }.toMutableList()
-
-            // 画像
-            val imageUri = it.sprites.other.officialArtwork.imgUrl
-
-            it.stats.onEach { stats ->
-                _conditionState.update { currentState ->
-                    when (stats.stat.name) {
-                        StatType.HP.type -> {
-                            currentState.copy(
-                                hp = stats.baseStat
-                            )
-                        }
-
-                        StatType.ATTACK.type -> currentState.copy(
-                            attack = stats.baseStat
+                    speciesNumber?.let { num ->
+                        // ポケモン特性を取得
+                        val species = detailRepository.getPokemonSpecies(num.toInt())
+                        // 必要情報を取得してconditionStateを更新
+                        getInfo(
+                            roomResult = roomResult,
+                            apiResult = apiResult,
+                            species = species
                         )
-
-                        StatType.DEFENSE.type -> currentState.copy(
-                            defense = stats.baseStat
+                    }
+                } else {
+                    //conditionStateを更新
+                    _conditionState.update { currentState ->
+                        currentState.copy(
+                            pokemonNumber = roomResult.id,
+                            englishName = roomResult.englishName ?: "",
+                            japaneseName = roomResult.japaneseName,
+                            description = roomResult.description ?: "",
+                            hp = roomResult.hp ?: 0,
+                            attack = roomResult.attack ?: 0,
+                            defense = roomResult.defense ?: 0,
+                            speed = roomResult.speed ?: 0,
+                            imageUri = roomResult.imageUrl ?: "",
+                            type = roomResult.type ?: emptyList(),
+                            genus = roomResult.genus ?: "",
+                            speciesNumber = roomResult.speciesNumber ?: ""
                         )
-
-                        StatType.SPEED.type -> currentState.copy(
-                            speed = stats.baseStat
-                        )
-
-                        else -> currentState
                     }
                 }
-            }
-
-            // id 日本語名　説明　属性
-            _conditionState.update { currentState ->
-                currentState.copy(
-                    pokemonNumber = species.id,
-                    name = name,
-                    type = type,
-                    description = description,
-                    genus = genus,
-                    imageUri = imageUri ?: "",
-                    height = it.height / 10.0,
-                    weight = it.weight / 10.0
+                // DBに保存
+                pokemonDataRepository.updatePokemonAllData(
+                    id = pokeId,
+                    englishName = conditionState.value.englishName,
+                    japaneseName = conditionState.value.japaneseName,
+                    description = conditionState.value.description,
+                    hp = conditionState.value.hp,
+                    attack = conditionState.value.attack,
+                    defense = conditionState.value.defense,
+                    speed = conditionState.value.speed,
+                    imageUrl = conditionState.value.imageUri,
+                    speciesNumber = conditionState.value.speciesNumber,
+                    type = conditionState.value.type,
+                    genus = conditionState.value.genus
                 )
             }
+        }.onSuccess {
             _uiState.emit(PokemonDetailUiState.Fetched(detailUiCondition = DetailUiCondition()))
         }.onFailure {
             send(PokemonDetailUiEvent.Error(it))
             _uiState.emit(PokemonDetailUiState.ResultError)
+        }
+    }
+
+    /**
+     * ポケモンの詳細情報を取得してStat更新
+     */
+    private fun getInfo(
+        roomResult: PokemonData?,
+        apiResult: PokemonPersonalData,
+        species: PokemonSpecies
+    ) {
+        // DBのデータが空だった場合はAPIから取得したデータをDBに保存
+        if (roomResult == null) {
+            _conditionState.update { currentState ->
+                currentState.copy(
+                    englishName = species.names.firstOrNull { names -> names.language.name == "en" }?.name
+                        ?: "",
+                    japaneseName = species.names.firstOrNull { names -> names.language.name == "ja" }?.name
+                        ?: "",
+                    description = species.flavorTextEntries.firstOrNull { flavorTextEntries ->
+                        flavorTextEntries.language.name == "ja"
+                    }?.flavorText ?: "",
+                    imageUri = apiResult.sprites.other.officialArtwork.imgUrl ?: "",
+                    speciesNumber = apiResult.id.toString()
+                )
+            }
+            // hp attack defense speed
+            apiResult.stats.forEach { item ->
+                _conditionState.update { currentState ->
+                    when (item.stat.name) {
+                        StatType.HP.type -> currentState.copy(hp = item.baseStat)
+                        StatType.ATTACK.type -> currentState.copy(attack = item.baseStat)
+                        StatType.DEFENSE.type -> currentState.copy(defense = item.baseStat)
+                        StatType.SPEED.type -> currentState.copy(speed = item.baseStat)
+                        else -> currentState
+                    }
+                }
+            }
+        } else {
+            // ポケモン説明がない場合
+            if (roomResult.description.isNullOrEmpty()) {
+                _conditionState.update { currentState ->
+                    currentState.copy(
+                        description = species.flavorTextEntries.firstOrNull { flavorTextEntries ->
+                            flavorTextEntries.language.name == "ja"
+                        }?.flavorText ?: ""
+                    )
+                }
+            } else {
+                _conditionState.update { currentState ->
+                    currentState.copy(
+                        description = roomResult.description
+                    )
+                }
+            }
+
+            // 画像URLがない場合
+            if (roomResult.imageUrl.isNullOrEmpty()) {
+                _conditionState.update { currentState ->
+                    currentState.copy(
+                        imageUri = apiResult.sprites.other.officialArtwork.imgUrl ?: ""
+                    )
+                }
+            } else {
+                _conditionState.update { currentState ->
+                    currentState.copy(
+                        imageUri = roomResult.imageUrl
+                    )
+                }
+            }
+
+            // speciesNumberがない場合
+            if(roomResult.speciesNumber.isNullOrEmpty()){
+                _conditionState.update { currentState ->
+                    currentState.copy(
+                        speciesNumber = apiResult.id.toString()
+                    )
+                }
+            }else {
+                _conditionState.update { currentState ->
+                    currentState.copy(
+                        speciesNumber = roomResult.speciesNumber
+                    )
+                }
+            }
+
+            // DB情報を使ってconditionStateを更新
+            _conditionState.update { currentState ->
+                currentState.copy(
+                    pokemonNumber = roomResult.id,
+                    englishName = roomResult.englishName ?: "",
+                    japaneseName = roomResult.japaneseName,
+                    hp = roomResult.hp ?: 0,
+                    attack = roomResult.attack ?: 0,
+                    defense = roomResult.defense ?: 0,
+                    speed = roomResult.speed ?: 0,
+                )
+            }
+        }
+        // 分類、タイプ、高さ、重さを取得（DBに存在しない）
+        _conditionState.update { currentState ->
+            currentState.copy(
+                genus = species.genera.firstOrNull { genera -> genera.language.name == "ja" }?.genus
+                    ?: "",
+                type = apiResult.types.map { types -> types.type.name },
+                height = apiResult.height / 10.0,
+                weight = apiResult.weight / 10.0
+            )
         }
     }
 

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Like/LikeState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Like/LikeState.kt
@@ -68,8 +68,8 @@ fun LikeDetails.toLike(): Like = Like(
  */
 fun PokemonDetailScreenUiData.toLikeDetails(): LikeDetails = LikeDetails(
     pokemonNumber = this.pokemonNumber,
-    name = this.name,
-    displayName = this.name,
+    name = this.japaneseName,
+    displayName = this.japaneseName,
     description = this.description,
     genus = this.genus,
     type = this.type,


### PR DESCRIPTION

## 対応内容

* PokemonDetailViewModelでDB検索してから必要な場合のみAPIを叩く処理に変更
* Roomのカラムを追加
* RoomにList型のカラムを保存するためのTypeConverterを実装
* PokemonDetailViewModelのインスタンスをタブごとに生成できるよう処理を変更




## スクリーンショット

見た目に関わる変更はなし