### PR TITLE
検索タイプ一覧取得と詳細画面周りの画面遷移周りのロジックを変更

### DIFF
--- a/app/src/main/java/com/example/pokebook/data/AppContainer.kt
+++ b/app/src/main/java/com/example/pokebook/data/AppContainer.kt
@@ -5,12 +5,14 @@ import com.example.pokebook.data.like.LikesRepository
 import com.example.pokebook.data.like.OfflineLikesRepository
 import com.example.pokebook.data.pokemonData.OfflinePokemonDataRepository
 import com.example.pokebook.data.pokemonData.PokemonDataRepository
+import com.example.pokebook.data.searchType.OfflineSearchTypeListRepository
+import com.example.pokebook.data.searchType.SearchTypeListRepository
 import com.example.pokebook.repository.DefaultHomeRepository
 import com.example.pokebook.repository.DefaultPokemonDetailRepository
 import com.example.pokebook.repository.DefaultSearchRepository
 import com.example.pokebook.repository.HomeRepository
 import com.example.pokebook.repository.PokemonDetailRepository
-import com.example.pokebook.repository.SearchRepository
+import com.example.pokebook.repository.ApiSearchRepository
 
 /**
  * 依存性注入のためのアプリコンテナ
@@ -18,9 +20,10 @@ import com.example.pokebook.repository.SearchRepository
 interface AppContainer {
     val likesRepository: LikesRepository
     val pokemonDataRepository: PokemonDataRepository
-    val searchRepository: SearchRepository
+    val searchRepository: ApiSearchRepository
     val pokemonDetailRepository: PokemonDetailRepository
     val homeRepository: HomeRepository
+    val searchTypeListRepository: SearchTypeListRepository
 }
 
 /**
@@ -36,7 +39,7 @@ class AppDataContainer(private val context: Context) : AppContainer {
     override val pokemonDataRepository: PokemonDataRepository by lazy {
         OfflinePokemonDataRepository(PokemonDatabase.getDatabase(context).pokemonDataDao())
     }
-    override val searchRepository: SearchRepository by lazy {
+    override val searchRepository: ApiSearchRepository by lazy {
         DefaultSearchRepository()
     }
     override val pokemonDetailRepository: PokemonDetailRepository by lazy {
@@ -44,5 +47,8 @@ class AppDataContainer(private val context: Context) : AppContainer {
     }
     override val homeRepository: HomeRepository by lazy {
         DefaultHomeRepository()
+    }
+    override val searchTypeListRepository: SearchTypeListRepository by lazy {
+        OfflineSearchTypeListRepository(PokemonDatabase.getDatabase(context).searchTypeListDao())
     }
 }

--- a/app/src/main/java/com/example/pokebook/data/PokemonDatabase.kt
+++ b/app/src/main/java/com/example/pokebook/data/PokemonDatabase.kt
@@ -11,12 +11,19 @@ import com.example.pokebook.data.like.LikeDao
 import com.example.pokebook.data.pokemonData.PokemonData
 import com.example.pokebook.data.pokemonData.PokemonDataDao
 import com.example.pokebook.data.pokemonData.StringListTypeConverter
+import com.example.pokebook.data.searchType.SearchTypeList
+import com.example.pokebook.data.searchType.SearchTypeListDao
 
-@Database(entities = [Like::class, PokemonData::class ], version = 1, exportSchema = false)
+@Database(
+    entities = [Like::class, PokemonData::class, SearchTypeList::class],
+    version = 1,
+    exportSchema = false
+)
 @TypeConverters(StringListTypeConverter::class)
 abstract class PokemonDatabase : RoomDatabase() {
     abstract fun likeDao(): LikeDao
     abstract fun pokemonDataDao(): PokemonDataDao
+    abstract fun searchTypeListDao(): SearchTypeListDao
 
     companion object {
         @Volatile

--- a/app/src/main/java/com/example/pokebook/data/like/Like.kt
+++ b/app/src/main/java/com/example/pokebook/data/like/Like.kt
@@ -16,4 +16,5 @@ data class Like(
     val name: String,
     val displayName: String,
     val imageUrl: String,
+    val speciesNumber:Int
 )

--- a/app/src/main/java/com/example/pokebook/data/pokemonData/OfflinePokemonDataRepository.kt
+++ b/app/src/main/java/com/example/pokebook/data/pokemonData/OfflinePokemonDataRepository.kt
@@ -33,6 +33,7 @@ class OfflinePokemonDataRepository(private val pokemonDataDao: PokemonDataDao) :
 
     override suspend fun updatePokemonAllData(
         id: Int?,
+        pokemonNumber: Int?,
         englishName: String?,
         japaneseName: String?,
         description: String?,
@@ -45,7 +46,7 @@ class OfflinePokemonDataRepository(private val pokemonDataDao: PokemonDataDao) :
         type: List<String>?,
         speciesNumber: String?
     ) = pokemonDataDao.updatePokemonAllData(
-        id = id,
+        pokemonNumber = pokemonNumber,
         englishName = englishName,
         japaneseName = japaneseName,
         description = description,

--- a/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonData.kt
+++ b/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonData.kt
@@ -1,6 +1,7 @@
 package com.example.pokebook.data.pokemonData
 
 import android.net.Uri
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Ignore
 import androidx.room.PrimaryKey
@@ -16,8 +17,9 @@ import com.example.pokebook.model.PokemonSpecies
 @Entity(tableName = "pokemonData")
 @TypeConverters(StringListTypeConverter::class)
 data class PokemonData(
-    @PrimaryKey(autoGenerate = true)
-    val id: Int = 0,
+    @PrimaryKey
+    @ColumnInfo(name = "id")
+    val pokemonNumber:Int = 0,
     val englishName: String? = "",
     val japaneseName: String = "",
     val genus: String? = "",
@@ -35,12 +37,7 @@ data class PokemonData(
  * PokemonPersonalData -> PokemonData
  */
 fun PokemonPersonalData.pokemonPersonalDataToPokemonData(): PokemonData = PokemonData(
+    pokemonNumber = this.id,
     imageUrl = this.sprites.other.officialArtwork.imgUrl ?: "",
     speciesNumber = if (!this.species.url.isNullOrEmpty()) Uri.parse(this.species.url).lastPathSegment else ""
-)
-
-/**
- * PokemonSpecies -> PokemonData
- */
-fun PokemonSpecies.convertSpeciesToPokemonData(): PokemonData = PokemonData(
 )

--- a/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonDataDao.kt
+++ b/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonDataDao.kt
@@ -36,17 +36,17 @@ interface PokemonDataDao {
     fun searchById(id: Int): PokemonData
 
     // 指定された範囲のデータの検索
-    @Query("SELECT id,imageUrl,japaneseName FROM pokemonData WHERE id BETWEEN :startId AND :endId")
+    @Query("SELECT id,imageUrl,japaneseName,speciesNumber FROM pokemonData WHERE id BETWEEN :startId AND :endId")
     fun getAllItemsBetweenIds(startId: Int, endId: Int): List<PokemonData>
 
     //　指定したIDのimageUrlとspeciesNumberにデータを挿入
     @Query("UPDATE pokemonData SET imageUrl = :imageUrl,speciesNumber = :speciesNumber WHERE id = :id")
     suspend fun updatePokemonData(id: Int, imageUrl: String, speciesNumber: String?)
 
-    // 指定したIDの必要なカラムを更新
-    @Query("UPDATE pokemonData SET englishName = :englishName, japaneseName = :japaneseName, description = :description,hp = :hp, attack = :attack, defense = :defense, speed = :speed, imageUrl = :imageUrl,speciesNumber = :speciesNumber,genus=:genus,type=:type WHERE id = :id")
+    // 指定したpokemonNumberの必要なカラムを更新
+    @Query("UPDATE pokemonData SET englishName = :englishName, japaneseName = :japaneseName, description = :description,hp = :hp, attack = :attack, defense = :defense, speed = :speed, imageUrl = :imageUrl,speciesNumber = :speciesNumber,genus=:genus,type=:type WHERE id = :pokemonNumber")
     suspend fun updatePokemonAllData(
-        id: Int? = null,
+        pokemonNumber: Int? = null,
         englishName: String? = null,
         japaneseName: String? = null,
         description: String? = null,

--- a/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonDataRepository.kt
+++ b/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonDataRepository.kt
@@ -50,6 +50,7 @@ interface PokemonDataRepository {
      */
     suspend fun updatePokemonAllData(
         id: Int?=null,
+        pokemonNumber:Int? = null,
         englishName: String? = null,
         japaneseName: String? = null,
         description: String? = null,

--- a/app/src/main/java/com/example/pokebook/data/searchType/OfflineSearchTypeListRepository.kt
+++ b/app/src/main/java/com/example/pokebook/data/searchType/OfflineSearchTypeListRepository.kt
@@ -1,0 +1,29 @@
+package com.example.pokebook.data.searchType
+
+class OfflineSearchTypeListRepository(private val searchTypeListDao: SearchTypeListDao) :
+    SearchTypeListRepository {
+    override suspend fun insert(searchTypeList: List<SearchTypeList>) =
+        searchTypeListDao.insert(searchTypeList)
+
+    override suspend fun update(searchType: SearchTypeList) =
+        searchTypeListDao.update(searchType)
+
+    override suspend fun searchByTypeNumber(typeNumber: Int): List<SearchTypeList> =
+        searchTypeListDao.searchByTypeNumber(typeNumber)
+
+    override suspend fun searchPokemonNumberByTypeNumber(typeNumber: Int): List<Int> =
+        searchTypeListDao.searchPokemonNumberByTypeNumber(typeNumber)
+
+    override suspend fun updateJapaneseName(pokemonNumber: Int, japaneseName: String) =
+        searchTypeListDao.updateJapaneseName(pokemonNumber, japaneseName)
+
+    override suspend fun updateSpeciesNumberAndImageUrl(
+        pokemonNumber: Int,
+        imageUrl: String,
+        speciesNumber: Int
+    ) = searchTypeListDao.updateSpeciesNumberAndImageUrl(
+        pokemonNumber,
+        imageUrl,
+        speciesNumber
+    )
+}

--- a/app/src/main/java/com/example/pokebook/data/searchType/SearchTypeList.kt
+++ b/app/src/main/java/com/example/pokebook/data/searchType/SearchTypeList.kt
@@ -1,0 +1,46 @@
+package com.example.pokebook.data.searchType
+
+import android.net.Uri
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.example.pokebook.model.PokemonListItem
+import com.example.pokebook.model.PokemonTypeSearchResult
+
+/**
+ * 初回起動時に検索タイプ一覧を取得するためのエンティティ
+ * データベーステーブル
+ */
+@Entity(tableName = "searchTypeList")
+data class SearchTypeList(
+    @PrimaryKey(autoGenerate = true)
+    val id: Int = 0,
+    val typeName: String = "",
+    val typeNumber: Int = 0,
+    val pokemonNumber: Int = 0,
+    val englishName: String = "",
+    val japaneseName: String? = "",
+    val imageUrl: String? = "",
+    val speciesNumber: Int = 0
+)
+
+/**
+ * PokemonTypeSearchResult -> SearchTypeList
+ */
+fun PokemonTypeSearchResult.toSearchTypeList(): List<SearchTypeList> {
+    val resultList = mutableListOf<SearchTypeList>()
+    val typeName = this.typeName.firstOrNull { it.language.name == "ja" }?.name ?: ""
+    val typeNumber = this.id
+
+    this.pokemon.forEach { pokemonItem ->
+        resultList.add(
+            SearchTypeList(
+                typeName = typeName,
+                typeNumber = typeNumber,
+                pokemonNumber = Uri.parse(pokemonItem.pokemonItem.url).lastPathSegment?.toInt()
+                    ?: 0,
+                englishName = pokemonItem.pokemonItem.name,
+            )
+        )
+    }
+    return resultList
+}

--- a/app/src/main/java/com/example/pokebook/data/searchType/SearchTypeListDao.kt
+++ b/app/src/main/java/com/example/pokebook/data/searchType/SearchTypeListDao.kt
@@ -1,0 +1,41 @@
+package com.example.pokebook.data.searchType
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+
+@Dao
+interface SearchTypeListDao {
+    //挿入
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insert(searchTypeList: List<SearchTypeList>)
+
+    // 同じ主キーを持つエンティティを更新
+    @Update
+    suspend fun update(searchType: SearchTypeList)
+
+    // typeNumber完全一致の検索(全カラム取得)
+    @Query("SELECT * FROM searchTypeList WHERE typeNumber = :typeNumber")
+    fun searchByTypeNumber(typeNumber: Int): List<SearchTypeList>
+
+    // typeNumber完全一致の検索(pokemonNumberカラム取得)
+    @Query("SELECT pokemonNumber FROM searchTypeList WHERE typeNumber = :typeNumber")
+    fun searchPokemonNumberByTypeNumber(typeNumber: Int): List<Int>
+
+    // 該当するpokemonNumberのimageUrlとspeciesNumberを保存する
+    @Query("UPDATE searchTypeList SET  imageUrl = :imageUrl, speciesNumber = :speciesNumber WHERE pokemonNumber = :pokemonNumber")
+    suspend fun updateSpeciesNumberAndImageUrl(
+        pokemonNumber: Int,
+        imageUrl: String,
+        speciesNumber: Int
+    )
+
+    // 該当するpokemonNumberのjapaneseNameを保存する
+    @Query("UPDATE searchTypeList SET  japaneseName = :japaneseName WHERE pokemonNumber = :pokemonNumber")
+    suspend fun updateJapaneseName(
+        pokemonNumber: Int,
+        japaneseName: String
+    )
+}

--- a/app/src/main/java/com/example/pokebook/data/searchType/SearchTypeListRepository.kt
+++ b/app/src/main/java/com/example/pokebook/data/searchType/SearchTypeListRepository.kt
@@ -1,0 +1,43 @@
+package com.example.pokebook.data.searchType
+
+/**
+ * 初回のポケモンタイプ別一覧取得で作成されたDBに対して操作を行うRepository
+ */
+interface SearchTypeListRepository {
+    /**
+     * 指定されたデータ・ソースからすべての項目を取得
+     */
+    suspend fun insert(searchTypeList: List<SearchTypeList>)
+
+    /**
+     * データソースの項目を更新
+     */
+    suspend fun update(searchType: SearchTypeList)
+
+    /**
+     * typeNumber完全一致の検索(全カラム取得)
+     */
+    suspend fun searchByTypeNumber(typeNumber: Int): List<SearchTypeList>
+
+    /**
+     * typeNumber完全一致の検索(pokemonNumberカラム取得)
+     */
+    suspend fun searchPokemonNumberByTypeNumber(typeNumber: Int): List<Int>
+
+    /**
+     * 該当するpokemonNumberのjapaneseNameとimageUrlを保存する
+     */
+    suspend fun updateSpeciesNumberAndImageUrl(
+        pokemonNumber: Int,
+        imageUrl: String,
+        speciesNumber:Int
+    )
+
+    /**
+     * 該当するpokemonNumberのjapaneseNameを保存する
+     */
+    suspend fun updateJapaneseName(
+        pokemonNumber: Int,
+        japaneseName: String
+        )
+}

--- a/app/src/main/java/com/example/pokebook/json/PokemonDataByJson.kt
+++ b/app/src/main/java/com/example/pokebook/json/PokemonDataByJson.kt
@@ -9,7 +9,8 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class PokemonDataByJson(
-    val id: Int,
+    @SerialName("id")
+    val pokemonNumber: Int,
     val name: Name,
     val type: List<String>,
     val base: Base
@@ -31,18 +32,4 @@ data class Base(
     val defense: Int,
     @SerialName("Speed")
     val speed: Int
-)
-
-/**
- * PokemonDataByJson -> PokemonData
- */
-fun PokemonDataByJson.toPokemonData(): PokemonData = PokemonData(
-    id = this.id,
-    englishName = this.name.english,
-    japaneseName = this.name.japanese,
-//    typy = this.type,
-    hp = this.base.hp,
-    attack = this.base.attack,
-    defense = this.base.defense,
-    speed = this.base.speed
 )

--- a/app/src/main/java/com/example/pokebook/model/PokemonTypeSearchResult.kt
+++ b/app/src/main/java/com/example/pokebook/model/PokemonTypeSearchResult.kt
@@ -8,13 +8,20 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class PokemonTypeSearchResult(
-    val pokemon: List<PokemonItem>
+    val pokemon: List<PokemonItem>,
+    val id: Int,
+    @SerialName("names")
+    val typeName: List<Name>
 )
 
 @Serializable
 data class PokemonItem(
     @SerialName("pokemon")
-    val pokemonItem:PokemonListItem
+    val pokemonItem: PokemonListItem
 )
 
-
+@Serializable
+data class Name(
+    val language: Language,
+    val name: String
+)

--- a/app/src/main/java/com/example/pokebook/repository/ApiSearchRepository.kt
+++ b/app/src/main/java/com/example/pokebook/repository/ApiSearchRepository.kt
@@ -1,18 +1,19 @@
 package com.example.pokebook.repository
 
+import android.util.Log
 import com.example.pokebook.model.PokemonPersonalData
 import com.example.pokebook.model.PokemonSpecies
 import com.example.pokebook.model.PokemonTypeSearchResult
 import com.example.pokebook.network.PokeApi
 import retrofit2.http.Path
 
-interface SearchRepository {
+interface ApiSearchRepository {
     suspend fun getPokemonPersonalData(pokemon: Int): PokemonPersonalData
     suspend fun getPokemonByType(@Path("path") typeNumber: String): PokemonTypeSearchResult
     suspend fun getPokemonSpecies(@Path("path") number: Int): PokemonSpecies
 }
 
-class DefaultSearchRepository : SearchRepository {
+class DefaultSearchRepository : ApiSearchRepository {
     override suspend fun getPokemonPersonalData(pokemon: Int): PokemonPersonalData {
         return PokeApi.retrofitService.getPokemonPersonalData(pokemon)
     }

--- a/app/src/main/java/com/example/pokebook/ui/AppViewModelProvider.kt
+++ b/app/src/main/java/com/example/pokebook/ui/AppViewModelProvider.kt
@@ -28,7 +28,8 @@ object AppViewModelProvider {
         }
         initializer {
             SearchViewModel(
-                pokemonApplication().container.searchRepository
+                pokemonApplication().container.searchRepository,
+                pokemonApplication().container.searchTypeListRepository
             )
         }
         initializer {

--- a/app/src/main/java/com/example/pokebook/ui/activity/MainActivity.kt
+++ b/app/src/main/java/com/example/pokebook/ui/activity/MainActivity.kt
@@ -1,55 +1,61 @@
 package com.example.pokebook.ui.activity
 
-import android.animation.ObjectAnimator
-import android.app.Application
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.view.View
 import android.view.ViewTreeObserver
-import android.view.animation.AnticipateInterpolator
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.activity.viewModels
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
-import androidx.core.animation.doOnEnd
+import androidx.core.app.AppLaunchChecker
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.pokebook.data.pokemonData.PokemonDataRepository
 import com.example.pokebook.ui.AppViewModelProvider
 import com.example.pokebook.ui.screen.Navigation.BottomNavigationView
 import com.example.pokebook.ui.theme.PokeBookTheme
 import com.example.pokebook.ui.viewModel.Main.MainViewModel
+import com.example.pokebook.ui.viewModel.Search.SearchViewModel
 
 class MainActivity : ComponentActivity() {
-    private lateinit var viewModel: MainViewModel
+    private lateinit var mainViewModel: MainViewModel
+    private lateinit var searchViewModel: SearchViewModel
 
     @RequiresApi(Build.VERSION_CODES.S)
     @OptIn(ExperimentalFoundationApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         // ViewModelProvider.Factoryを使ってViewModelを初期化
-        viewModel = ViewModelProvider(this, AppViewModelProvider.Factory)[MainViewModel::class.java]
+        mainViewModel =
+            ViewModelProvider(this, AppViewModelProvider.Factory)[MainViewModel::class.java]
+        searchViewModel =
+            ViewModelProvider(this, AppViewModelProvider.Factory)[SearchViewModel::class.java]
 
         installSplashScreen()
 
         val content: View = findViewById(android.R.id.content)
+        var isReady=false
 
-        viewModel.readJson()
+        // 初回起動時のみ実施
+        if (!AppLaunchChecker.hasStartedFromLauncher(this)) {
+            mainViewModel.readJson()
+            searchViewModel.getPokemonTypeList()
+            AppLaunchChecker.onActivityCreate(this)
+        }else{
+            isReady = true
+        }
 
         // スプラッシュ画面の表示時間延長を判定
         content.viewTreeObserver.addOnPreDrawListener(
             object : ViewTreeObserver.OnPreDrawListener {
                 override fun onPreDraw(): Boolean {
                     // 準備ができた場合は、trueで描画開始、準備中の場合は、falseで一時停止。
-                    return if (viewModel.isReady.value == true) {
+                    return if (searchViewModel.isReady.value == true || isReady) {
                         // HOMEタブ表示
                         setContent {
                             PokeBookTheme {

--- a/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
@@ -1,6 +1,7 @@
 package com.example.pokebook.ui.screen
 
 import android.annotation.SuppressLint
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -52,7 +53,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun HomeScreen(
     homeViewModel: HomeViewModel,
-    onClickCard: (Int) -> Unit
+    onClickCard: (Int, Int) -> Unit
 ) {
     HomeScreen(
         uiState = homeViewModel.uiState,
@@ -76,7 +77,7 @@ private fun HomeScreen(
     consumeEvent: (HomeUiEvent) -> Unit,
     onClickNext: () -> Unit,
     onClickBack: () -> Unit,
-    onClickCard: (Int) -> Unit,
+    onClickCard: (Int, Int) -> Unit,
     updateIsFirst: (Boolean) -> Unit,
     onClickRetryGetList: () -> Unit
 ) {
@@ -145,7 +146,7 @@ private fun PokeList(
     isFirst: Boolean,
     onClickNext: () -> Unit,
     onClickBack: () -> Unit,
-    onClickCard: (Int) -> Unit,
+    onClickCard: (Int, Int) -> Unit,
     updateIsFirst: (Boolean) -> Unit,
     lazyGridState: LazyGridState,
     coroutineScope: CoroutineScope
@@ -183,7 +184,7 @@ private fun PokeList(
 fun PokeList(
     pokemonUiDataList: List<PokemonListUiData>,
     isFirst: Boolean,
-    onClickCard: (Int) -> Unit,
+    onClickCard: (Int, Int) -> Unit,
     updateIsFirst: (Boolean) -> Unit,
     lazyGridState: LazyGridState,
     coroutineScope: CoroutineScope
@@ -213,13 +214,15 @@ fun PokeList(
 @Composable
 fun PokeCard(
     pokemon: PokemonListUiData,
-    onClickCard: (Int) -> Unit,
+    onClickCard: (Int, Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Card(
         modifier = modifier.padding(8.dp),
         elevation = cardElevation(4.dp),
-        onClick = { onClickCard.invoke(pokemon.pokemonNumber) }
+        onClick = {
+            Log.d("test","詳細画面を開く時の情報：$pokemon")
+            onClickCard.invoke(pokemon.speciesNumber?.toInt() ?: 0, pokemon.pokemonNumber) }
     ) {
         Box(
             contentAlignment = Alignment.BottomCenter

--- a/app/src/main/java/com/example/pokebook/ui/screen/LikeEntryScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/LikeEntryScreen.kt
@@ -52,7 +52,7 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun LikeEntryScreen(
-    onClickCard: (Int) -> Unit,
+    onClickCard: (Int, Int) -> Unit,
     onClickBackButton: () -> Unit,
     likeEntryViewModel: LikeEntryViewModel
 ) {
@@ -73,7 +73,7 @@ private fun LikeEntryBody(
     uiState: StateFlow<LikeUiState>,
     uiEventState: Flow<LikeUiEvent?>,
     consumeEvent: (LikeUiEvent) -> Unit,
-    onClickCard: (Int) -> Unit,
+    onClickCard: (Int, Int) -> Unit,
     onClickBackButton: () -> Unit,
     updateIsLike: (Boolean, Int) -> Unit,
     deleteLike: suspend (LikeDetails) -> Unit,
@@ -129,7 +129,7 @@ private fun LikeEntryBody(
 @Composable
 fun LikeScreen(
     likeList: MutableList<LikeDetails>,
-    onClickCard: (Int) -> Unit,
+    onClickCard: (Int, Int) -> Unit,
     updateIsLike: (Boolean, Int) -> Unit,
     deleteLike: suspend (LikeDetails) -> Unit,
     getAllList: () -> Unit,
@@ -167,7 +167,7 @@ fun LikeScreen(
 @Composable
 private fun LikePokeCard(
     pokemon: LikeDetails,
-    onClickCard: (Int) -> Unit,
+    onClickCard: (Int, Int) -> Unit,
     updateIsLike: (Boolean, Int) -> Unit,
     deleteLike: suspend (LikeDetails) -> Unit,
     getAllList: () -> Unit,
@@ -177,7 +177,7 @@ private fun LikePokeCard(
         modifier = modifier.padding(8.dp),
         elevation = CardDefaults.cardElevation(4.dp),
         onClick = {
-            onClickCard.invoke(pokemon.pokemonNumber)
+            onClickCard.invoke(pokemon.speciesNumber, pokemon.pokemonNumber)
         },
     ) {
         Box(

--- a/app/src/main/java/com/example/pokebook/ui/screen/Navigation/BottomNavigationScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/Navigation/BottomNavigationScreen.kt
@@ -91,22 +91,24 @@ fun NavGraphBuilder.homeGraph(
         route = BottomNavItems.Home.route
     ) {
         composable(HomeScreen.PokemonListScreen.route) {
-            homeViewModel.getPokemonList()
             HomeScreen(
                 homeViewModel = homeViewModel,
-                onClickCard = { pokemonNumber ->
-                    navController.navigate("${HomeScreen.PokemonDetailScreen.route}/$pokemonNumber")
+                onClickCard = { speciesNumber, pokemonNumber ->
+                    navController.navigate("${HomeScreen.PokemonDetailScreen.route}/$speciesNumber/$pokemonNumber")
                 }
             )
         }
         composable(
-            route = "${HomeScreen.PokemonDetailScreen.route}/{pokemonNumber}",
+            route = "${HomeScreen.PokemonDetailScreen.route}/{speciesNumber}/{pokemonNumber}",
             arguments = listOf(
+                navArgument("speciesNumber") { type = NavType.IntType },
                 navArgument("pokemonNumber") { type = NavType.IntType }
             )
         ) { backStackEntry ->
+            val speciesNumber = backStackEntry.arguments?.getInt("speciesNumber") ?: 0
             val pokemonNumber = backStackEntry.arguments?.getInt("pokemonNumber") ?: 0
             PokemonDetailScreen(
+                speciesNumber = speciesNumber,
                 pokemonNumber = pokemonNumber,
                 likeEntryViewModel = likeEntryViewModel,
                 onClickBackButton = { navController.navigateUp() }
@@ -129,21 +131,29 @@ fun NavGraphBuilder.searchGraph(
     ) {
         composable(SearchScreen.SearchTopScreen.route) {
             SearchScreen(
-                searchViewModel = searchViewModel,
                 onClickSearchNumber = { pokemonNumber ->
                     navController.navigate("${SearchScreen.PokemonDetailScreenByNumber.route}/$pokemonNumber")
                 },
                 onClickSearchName = { pokemonName ->
                     navController.navigate("${SearchScreen.PokemonDetailScreenByName.route}/$pokemonName")
                 },
-                onClickSearchTypeButton = { navController.navigate(SearchScreen.PokemonListScreen.route) },
+                onClickSearchTypeButton = { typeNumber ->
+                    navController.navigate("${SearchScreen.PokemonListScreen.route}/$typeNumber")
+                },
             )
         }
-        composable(SearchScreen.PokemonListScreen.route) {
+        composable(
+            route = "${SearchScreen.PokemonListScreen.route}/{typeNumber}",
+            arguments = listOf(
+                navArgument("typeNumber") { type = NavType.IntType }
+            )
+        ) { backStackEntry ->
+            val typeNumber = backStackEntry.arguments?.getInt("typeNumber") ?: 0
             SearchListScreen(
+                typeNumber = typeNumber,
                 searchViewModel = searchViewModel,
-                onClickCard = { pokemonNumber ->
-                    navController.navigate("${SearchScreen.PokemonDetailScreenByNumber.route}/$pokemonNumber")
+                onClickCard = { speciesNumber, pokemonNumber ->
+                    navController.navigate("${SearchScreen.PokemonDetailScreenByNumber.route}/$speciesNumber/$pokemonNumber")
                 },
                 onClickBackSearchScreen = { navController.navigateUp() }
             )
@@ -167,13 +177,16 @@ fun NavGraphBuilder.searchGraph(
             )
         }
         composable(
-            route = "${SearchScreen.PokemonDetailScreenByNumber.route}/{pokemonNumber}",
+            route = "${SearchScreen.PokemonDetailScreenByNumber.route}/{speciesNumber}/{pokemonNumber}",
             arguments = listOf(
-                navArgument("pokemonNumber") { type = NavType.IntType },
+                navArgument("speciesNumber") { type = NavType.IntType },
+                navArgument("pokemonNumber") { type = NavType.IntType }
             )
         ) { backStackEntry ->
+            val speciesNumber = backStackEntry.arguments?.getInt("speciesNumber") ?: 0
             val pokemonNumber = backStackEntry.arguments?.getInt("pokemonNumber") ?: 0
             PokemonDetailScreen(
+                speciesNumber = speciesNumber,
                 pokemonNumber = pokemonNumber,
                 likeEntryViewModel = likeEntryViewModel,
                 onClickBackButton = { navController.navigateUp() }
@@ -196,21 +209,24 @@ fun NavGraphBuilder.likeGraph(
         composable(LikeScreen.LikeListScreen.route) {
             likeEntryViewModel.getAllList()
             LikeEntryScreen(
-                onClickCard = { pokemonNumber ->
-                    navController.navigate("${LikeScreen.LikeDetailScreen.route}/$pokemonNumber")
+                onClickCard = { speciesNumber, pokemonNumber ->
+                    navController.navigate("${LikeScreen.LikeDetailScreen.route}/$speciesNumber/$pokemonNumber")
                 },
                 onClickBackButton = { navController.navigateUp() },
                 likeEntryViewModel = likeEntryViewModel
             )
         }
         composable(
-            route = "${LikeScreen.LikeDetailScreen.route}/{pokemonNumber}",
+            route = "${LikeScreen.LikeDetailScreen.route}/{speciesNumber}/{pokemonNumber}",
             arguments = listOf(
+                navArgument("speciesNumber") { type = NavType.IntType },
                 navArgument("pokemonNumber") { type = NavType.IntType },
             )
         ) { backStackEntry ->
+            val speciesNumber = backStackEntry.arguments?.getInt("speciesNumber") ?: 0
             val pokemonNumber = backStackEntry.arguments?.getInt("pokemonNumber") ?: 0
             PokemonDetailScreen(
+                speciesNumber = speciesNumber,
                 pokemonNumber = pokemonNumber,
                 likeEntryViewModel = likeEntryViewModel,
                 onClickBackButton = { navController.navigateUp() }

--- a/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
@@ -49,6 +49,7 @@ import com.example.pokebook.ui.viewModel.Detail.PokemonDetailScreenUiData
 import com.example.pokebook.ui.viewModel.Detail.PokemonDetailUiEvent
 import com.example.pokebook.ui.viewModel.Detail.PokemonDetailUiState
 import com.example.pokebook.ui.viewModel.Detail.PokemonDetailViewModel
+import com.example.pokebook.ui.viewModel.Home.PokemonListUiData
 import com.example.pokebook.ui.viewModel.Like.LikeDetails
 import com.example.pokebook.ui.viewModel.Like.LikeEntryViewModel
 import com.example.pokebook.ui.viewModel.Like.toLikeDetails
@@ -58,15 +59,16 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun PokemonDetailScreen(
+    speciesNumber: Int = 0,
     pokemonNumber: Int? = null,
-    pokemonName: String? = null,
+    pokemonName: String? = "",
     likeEntryViewModel: LikeEntryViewModel,
     pokemonDetailViewModel: PokemonDetailViewModel = viewModel(factory = AppViewModelProvider.Factory),
     onClickBackButton: () -> Unit
 ) {
     if (pokemonNumber != null) {
-        pokemonDetailViewModel.getPokemonSpeciesById(pokemonNumber)
-    } else if (pokemonName != null) {
+        pokemonDetailViewModel.getPokemonSpeciesById(pokemonNumber, speciesNumber)
+    } else if (!pokemonName.isNullOrEmpty()) {
         pokemonDetailViewModel.getPokemonSpeciesByName(pokemonName)
     } else {
         // 何もしない
@@ -157,6 +159,7 @@ private fun PokemonDetailScreen(
 ) {
     Column(
         modifier = Modifier
+            .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
             .verticalScroll(
                 state = rememberScrollState(),

--- a/app/src/main/java/com/example/pokebook/ui/screen/SearchListScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/SearchListScreen.kt
@@ -1,6 +1,7 @@
 package com.example.pokebook.ui.screen
 
 import android.annotation.SuppressLint
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -48,10 +49,13 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun SearchListScreen(
+    typeNumber: Int,
     searchViewModel: SearchViewModel,
-    onClickCard: (Int) -> Unit,
+    onClickCard: (Int, Int) -> Unit,
     onClickBackSearchScreen: () -> Unit
 ) {
+    searchViewModel.showPokemonTypeList(typeNumber)
+
     SearchListScreen(
         uiState = searchViewModel.uiState,
         uiStateEvent = searchViewModel.uiEvent,
@@ -76,7 +80,7 @@ private fun SearchListScreen(
     conditionState: StateFlow<SearchConditionState>,
     onClickBack: () -> Unit,
     onClickNext: () -> Unit,
-    onClickCard: (Int) -> Unit,
+    onClickCard: (Int, Int) -> Unit,
     updateButtonStates: (Boolean, Boolean) -> Unit,
     updateIsFirst: (Boolean) -> Unit,
     onClickBackSearchScreen: () -> Unit,
@@ -154,7 +158,7 @@ private fun SearchListScreen(
     maxPage: String,
     onClickBack: () -> Unit,
     onClickNext: () -> Unit,
-    onClickCard: (Int) -> Unit,
+    onClickCard: (Int, Int) -> Unit,
     updateButtonStates: (Boolean, Boolean) -> Unit,
     updateIsFirst: (Boolean) -> Unit,
     onClickBackSearchScreen: () -> Unit,
@@ -202,7 +206,7 @@ private fun SearchListScreen(
 private fun PokeTypeList(
     pokemonUiDataList: List<PokemonListUiData>,
     isFirst: Boolean,
-    onClickCard: (Int) -> Unit,
+    onClickCard: (Int, Int) -> Unit,
     updateIsFirst: (Boolean) -> Unit,
     lazyGridState: LazyGridState,
     coroutineScope: CoroutineScope
@@ -234,15 +238,13 @@ private fun PokeTypeList(
 @Composable
 private fun PokeTypeCard(
     pokemon: PokemonListUiData,
-    onClickCard: (Int) -> Unit,
+    onClickCard: (Int, Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Card(
         modifier = modifier.padding(8.dp),
         elevation = CardDefaults.cardElevation(4.dp),
-        onClick = {
-            onClickCard.invoke(pokemon.pokemonNumber)
-        }
+        onClick = { onClickCard.invoke(pokemon.speciesNumber?.toInt() ?: 0, pokemon.pokemonNumber) }
     ) {
         if (!pokemon.imageUrl.isNullOrEmpty()) {
             Box(

--- a/app/src/main/java/com/example/pokebook/ui/screen/SearchScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/SearchScreen.kt
@@ -37,25 +37,9 @@ import com.example.pokebook.ui.viewModel.Search.SearchViewModel
 @SuppressLint("StateFlowValueCalledInComposition")
 @Composable
 fun SearchScreen(
-    searchViewModel: SearchViewModel,
     onClickSearchName: (String) -> Unit,
     onClickSearchNumber: (Int) -> Unit,
-    onClickSearchTypeButton: () -> Unit,
-) {
-    SearchScreen(
-        onClickSearchType = searchViewModel::getPokemonByType,
-        onClickSearchName = onClickSearchName,
-        onClickSearchNumber = onClickSearchNumber,
-        onClickSearchTypeButton = onClickSearchTypeButton
-    )
-}
-
-@Composable
-private fun SearchScreen(
-    onClickSearchType: (String) -> Unit,
-    onClickSearchName: (String) -> Unit,
-    onClickSearchNumber: (Int) -> Unit,
-    onClickSearchTypeButton: () -> Unit,
+    onClickSearchTypeButton: (Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
     var valueName by remember { mutableStateOf("") }
@@ -69,7 +53,6 @@ private fun SearchScreen(
             .background(androidx.compose.material3.MaterialTheme.colorScheme.background)
     ) {
         SearchType(
-            onClickType = onClickSearchType,
             onClickSearchTypeButton = onClickSearchTypeButton
         )
         SearchName(
@@ -93,8 +76,7 @@ private fun SearchScreen(
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun SearchType(
-    onClickType: (String) -> Unit,
-    onClickSearchTypeButton: () -> Unit,
+    onClickSearchTypeButton: (Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -129,8 +111,7 @@ private fun SearchType(
                         )
                         .padding(2.dp)
                         .clickable {
-                            onClickType.invoke(item.convertToTypeNumber())
-                            onClickSearchTypeButton.invoke()
+                            onClickSearchTypeButton.invoke(item.convertToTypeNumber())
                         }
                 )
             }

--- a/app/src/main/java/com/example/pokebook/ui/screen/TypeTag.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/TypeTag.kt
@@ -112,8 +112,8 @@ enum class TypeName(
 /**
  * 日本語名 -> TypeNumber
  */
-fun String.convertToTypeNumber(): String {
-    return TypeName.values().find { it.jaTypeName == this }?.number ?: ""
+fun String.convertToTypeNumber(): Int {
+    return TypeName.values().find { it.jaTypeName == this }?.number?.toInt() ?: 0
 }
 
 /**

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailState.kt
@@ -1,5 +1,6 @@
 package com.example.pokebook.ui.viewModel.Detail
 
+import com.example.pokebook.model.PokemonPersonalData
 import java.util.UUID
 
 /**

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Home/HomeState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Home/HomeState.kt
@@ -1,5 +1,7 @@
 package com.example.pokebook.ui.viewModel.Home
 
+import android.os.Parcel
+import android.os.Parcelable
 import java.util.UUID
 
 /**
@@ -12,7 +14,7 @@ sealed class HomeUiState {
     ) : HomeUiState()
 
     object InitialState : HomeUiState()
-    object ResultError: HomeUiState()
+    object ResultError : HomeUiState()
 }
 
 /**
@@ -27,13 +29,13 @@ data class PokemonListUiData(
     val name: String = "",
     var displayName: String = "",
     val url: String = "",
-    var imageUrl: String? = ""
+    var imageUrl: String? = "",
+    val speciesNumber: String? = ""
 )
 
 data class HomeScreenConditionState(
-    val isScrollTop:Boolean = true,
-    val pagePosition:Int = 0,
-    val speciesNumber:String? = ""
+    val isScrollTop: Boolean = true,
+    val pagePosition: Int = 0,
 )
 
 /**

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Home/HomeViewModel.kt
@@ -49,6 +49,10 @@ class HomeViewModel(
 
     private val uiDataList = mutableListOf<PokemonListUiData>()
 
+    init {
+        if (uiDataList.isEmpty()) getPokemonList()
+    }
+
     /**
      * ポケモンリスト取得
      */
@@ -60,29 +64,26 @@ class HomeViewModel(
         runCatching {
             for (index in dbList) {
                 if (index.imageUrl?.isEmpty() == true) {
-                    // 画像URL情報がない場合はAPIから取得してくる
-                    val pokemonPersonalData = getPokemonPersonalData(index.id)
+                    // DBに画像URL情報がない場合はAPIから取得してくる
+                    val pokemonPersonalData = getPokemonPersonalData(index.pokemonNumber)
                     pokemonPersonalData.imageUrl?.let {
                         updatePokemonData(
-                            indexId = index.id,
+                            indexId = index.pokemonNumber,
                             pokemonPersonalData = pokemonPersonalData
                         )
                     }
                     uiDataList += PokemonListUiData(
-                        pokemonNumber = index.id,
+                        pokemonNumber = index.pokemonNumber,
                         displayName = index.japaneseName,
-                        imageUrl = pokemonPersonalData.imageUrl
+                        imageUrl = pokemonPersonalData.imageUrl,
+                        speciesNumber = pokemonPersonalData.speciesNumber
                     )
-                    _conditionState.update { currentState ->
-                        currentState.copy(
-                            speciesNumber = pokemonPersonalData.speciesNumber
-                        )
-                    }
                 } else {
                     uiDataList += PokemonListUiData(
-                        pokemonNumber = index.id,
+                        pokemonNumber = index.pokemonNumber,
                         displayName = index.japaneseName,
-                        imageUrl = index.imageUrl
+                        imageUrl = index.imageUrl,
+                        speciesNumber = index.speciesNumber
                     )
                 }
             }

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Like/LikeState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Like/LikeState.kt
@@ -39,7 +39,8 @@ data class LikeDetails(
     val imageUrl: String = "",
     val height: Double = 0.0,
     val weight: Double = 0.0,
-    var isLike: Boolean = true
+    var isLike: Boolean = true,
+    var speciesNumber:Int =0
 )
 
 /**
@@ -60,6 +61,7 @@ fun LikeDetails.toLike(): Like = Like(
     name = name,
     displayName = displayName,
     imageUrl = imageUrl,
+    speciesNumber = speciesNumber
 )
 
 
@@ -80,7 +82,8 @@ fun PokemonDetailScreenUiData.toLikeDetails(): LikeDetails = LikeDetails(
     imageUrl = this.imageUri,
     height = this.height,
     weight = this.weight,
-    isLike = this.isLike
+    isLike = this.isLike,
+    speciesNumber = this.speciesNumber.toInt()
 )
 
 /**
@@ -106,7 +109,8 @@ fun List<Like>.toPokemonListUiDataList(): MutableList<LikeDetails> {
                 name = like.name,
                 displayName = like.displayName,
                 imageUrl = like.imageUrl,
-                isLike = true
+                isLike = true,
+                speciesNumber = like.speciesNumber
             )
         }
     )

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Main/MainViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Main/MainViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.pokebook.data.PokemonDatabase
 import com.example.pokebook.data.pokemonData.PokemonData
 import com.example.pokebook.data.pokemonData.PokemonDataRepository
 import com.example.pokebook.data.pokemonData.pokemonDataByJson
@@ -15,16 +16,12 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
+import android.database.sqlite.SQLiteDatabase
+import android.util.Log
 
 class MainViewModel(
     private val pokemonDataRepository: PokemonDataRepository
 ) : ViewModel() {
-    //    private val _isDataReady: MutableStateFlow<Boolean> = MutableStateFlow(false)
-//    val isDataReady = _isDataReady.asStateFlow()
-// TODO LiveDataとFlowどちらが適切なのか？
-    private val _isReady: MutableLiveData<Boolean> = MutableLiveData(false)
-    val isReady: LiveData<Boolean> get() = _isReady
-
     private val json = Json {
         ignoreUnknownKeys = true
     }
@@ -40,13 +37,10 @@ class MainViewModel(
                 // DB書き込み
                 convertAndWriteToDB(pokemonList)
             }
-            delay(2000) // DB書き込みがない場合スプラッシュが一瞬で消えるため、デフォルト２秒表示させる
         }.onSuccess {
-//            _isDataReady.emit(true)
-            _isReady.postValue(true)
+            // 次のメソッドに移行するため、何もしない
         }.onFailure {
-//            _isDataReady.emit(false)
-            _isReady.postValue(false)
+           //TODO いずれエラー処理を実装
         }
     }
 
@@ -56,7 +50,7 @@ class MainViewModel(
     private suspend fun convertAndWriteToDB(pokemonList: List<PokemonDataByJson>) {
         val pokemonDataList = pokemonList.map {
             PokemonData(
-                id = it.id,
+                pokemonNumber = it.pokemonNumber,
                 englishName = it.name.english,
                 japaneseName = it.name.japanese,
                 hp = it.base.hp,

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Search/SearchViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Search/SearchViewModel.kt
@@ -2,24 +2,20 @@ package com.example.pokebook.ui.viewModel.Search
 
 import android.net.Uri
 import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.pokebook.data.pokemonData.PokemonDataRepository
-import com.example.pokebook.model.PokemonPersonalData
-import com.example.pokebook.model.PokemonSpecies
-import com.example.pokebook.model.StatType
-import com.example.pokebook.repository.PokemonDetailRepository
-import com.example.pokebook.repository.SearchRepository
+import com.example.pokebook.data.searchType.SearchTypeListRepository
+import com.example.pokebook.data.searchType.toSearchTypeList
+import com.example.pokebook.repository.ApiSearchRepository
 import com.example.pokebook.ui.screen.convertToJaTypeName
 import com.example.pokebook.ui.viewModel.DefaultHeader
-import com.example.pokebook.ui.viewModel.Detail.PokemonDetailScreenUiData
-import com.example.pokebook.ui.viewModel.Detail.PokemonDetailUiState
 import com.example.pokebook.ui.viewModel.Home.PokemonListUiData
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
@@ -27,9 +23,31 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 const val DISPLAY_UI_DATA_LIST_ITEM = 20
+const val TYPE_NORMAL = "1"
+const val TYPE_FIGHTING = "2"
+const val TYPE_FLYING = "3"
+const val TYPE_POISON = "4"
+const val TYPE_GROUND = "5"
+const val TYPE_ROCK = "6"
+const val TYPE_BUG = "7"
+const val TYPE_GHOST = "8"
+const val TYPE_STEEL = "9"
+const val TYPE_FIRE = "10"
+const val TYPE_WATER = "11"
+const val TYPE_GRASS = "12"
+const val TYPE_ELECTRIC = "13"
+const val TYPE_PSYCHIC = "14"
+const val TYPE_ICE = "15"
+const val TYPE_DRAGON = "16"
+const val TYPE_DARK = "17"
+const val TYPE_FAIRY = "18"
+const val TYPE_UNKNOWN = "10001"
+const val TYPE_SHADOW = "10002"
 
-class SearchViewModel(private val searchRepository: SearchRepository) : ViewModel(),
-    DefaultHeader {
+class SearchViewModel(
+    private val searchRepository: ApiSearchRepository,
+    private val searchTypeListRepository: SearchTypeListRepository
+) : ViewModel(), DefaultHeader {
     private var _uiState: MutableStateFlow<SearchUiState> =
         MutableStateFlow(SearchUiState.InitialState)
     val uiState = _uiState.asStateFlow()
@@ -40,9 +58,6 @@ class SearchViewModel(private val searchRepository: SearchRepository) : ViewMode
 
     // APIから取得したタイプ別一覧を格納するリスト
     private val responseUiDataList = mutableListOf<List<PokemonListUiData>>()
-
-    // 表示用のタイプ別一覧リスト（20件ずつ）
-    private var displayUiDataList = mutableListOf<SearchedListData>()
 
     private val _uiEvent: MutableStateFlow<List<SearchUiEvent>> = MutableStateFlow(listOf())
     val uiEvent: Flow<SearchUiEvent?>
@@ -58,113 +73,175 @@ class SearchViewModel(private val searchRepository: SearchRepository) : ViewMode
         _uiEvent.emit(_uiEvent.value.filterNot { it == event })
     }
 
+    // splash画面起動して良いかどうか
+    private val _isReady: MutableLiveData<Boolean> = MutableLiveData(false)
+    val isReady: LiveData<Boolean> get() = _isReady
+
+    private val searchedTypeList = mutableListOf<SearchedType>()
+
     /**
-     * Type検索
+     * 初回起動でAPIからType一覧を取得してDBに保存
      */
-    fun getPokemonByType(typeNumber: String) = viewModelScope.launch {
-        _uiState.emit(SearchUiState.Loading)
-        // 検索一覧画面のタイトル更新
-        _conditionState.update { currentState ->
-            currentState.copy(
-                pokemonTypeName = typeNumber.convertToJaTypeName(),
-            )
-        }
+    fun getPokemonTypeList() = viewModelScope.launch {
+        val typeNumbers = listOf(
+            TYPE_NORMAL,
+            TYPE_FIGHTING,
+            TYPE_FLYING,
+            TYPE_POISON,
+            TYPE_GROUND,
+            TYPE_ROCK,
+            TYPE_BUG,
+            TYPE_GHOST,
+            TYPE_STEEL,
+            TYPE_FIRE,
+            TYPE_WATER,
+            TYPE_GRASS,
+            TYPE_ELECTRIC,
+            TYPE_PSYCHIC,
+            TYPE_ICE,
+            TYPE_DRAGON,
+            TYPE_DARK,
+            TYPE_FAIRY,
+            TYPE_UNKNOWN,
+            TYPE_SHADOW
+        )
         runCatching {
-            searchRepository.getPokemonByType(typeNumber)
+            for (typeNumber in typeNumbers) {
+                // APIからタイプ別リストを取得
+                val typeList =
+                    searchRepository.getPokemonByType(typeNumber).toSearchTypeList()
+                // DBに保存
+                searchTypeListRepository.insert(typeList)
+                withContext(Dispatchers.IO) {
+                    // DBから該当する一覧を取得（全カラム）
+                    val roomResult = searchTypeListRepository.searchByTypeNumber(typeNumber.toInt())
+                    // 不足データがあればAPIから取得してDB保存する
+                    roomResult.forEach { item ->
+                        if (item.japaneseName.isNullOrEmpty()) {
+                            //APIから取得
+                            val pokemonPersonalData =
+                                searchRepository.getPokemonPersonalData(item.pokemonNumber)
+                            val imageUrl = pokemonPersonalData.sprites.other.officialArtwork.imgUrl
+                                ?: ""
+                            val speciesNumber =
+                                Uri.parse(pokemonPersonalData.species.url).lastPathSegment?.toInt()
+                                    ?: 0
+                            // DBに保存
+                            searchTypeListRepository.updateSpeciesNumberAndImageUrl(
+                                pokemonNumber = item.pokemonNumber,
+                                imageUrl = imageUrl,
+                                speciesNumber = speciesNumber
+                            )
+                        }
+                    }
+                }
+            }
         }.onSuccess {
-            _conditionState.update { currentState ->
-                currentState.copy(
-                    maxPage = it.pokemon.size.div(DISPLAY_UI_DATA_LIST_ITEM).plus(1).toString(),
-                )
-            }
-
-            if (it.pokemon.isEmpty()) {
-                _uiState.emit(SearchUiState.Fetched(emptyList()))
-                return@launch
-            }
-
-            val chunkedList = it.pokemon.map { item ->
-                PokemonListUiData(
-                    name = item.pokemonItem.name,
-                    url = item.pokemonItem.url
-                )
-            }.chunked(DISPLAY_UI_DATA_LIST_ITEM).toMutableList()
-
-            // 最後のリストを調整
-            val lastChunk = chunkedList.lastOrNull()?.take(DISPLAY_UI_DATA_LIST_ITEM)
-            if (lastChunk != null) {
-                chunkedList[chunkedList.size.minus(1)] = lastChunk
-            }
-            responseUiDataList.clear()
-            responseUiDataList += chunkedList
-            displayUiDataList = responseUiDataList.map { item ->
-                SearchedListData(item, false)
-            }.toMutableList()
-
-            updateDisplayUiDataList()
+            _isReady.postValue(true)
         }.onFailure {
-            send(SearchUiEvent.Error(it))
-            _uiState.emit(SearchUiState.ResultError)
+            _isReady.postValue(false)
+            Log.d("error", "e[getPokemonTypeList]：$it") // TODO　いずれエラーダイアログ遷移
         }
-
     }
 
     /**
-     * 画像url、id、ポケモン日本語名を取得
+     * DBから指定されたType一覧を取得して表示
      */
-    private fun updateDisplayUiDataList(pagePosition: Int = 0) = viewModelScope.launch {
-        val personalDataList = mutableListOf<PokemonPersonalData>()
-        val speciesList = mutableListOf<PokemonSpecies>()
-        val urlList = responseUiDataList[pagePosition].map { page -> page.url }
+    fun showPokemonTypeList(typeNumber: Int) = viewModelScope.launch {
+        // リスト取得済みかどうかを確認
+        searchedTypeList.forEach { item ->
+            if (item.typeNumber == typeNumber && item.isFetched) return@launch
+        }
 
+        _uiState.emit(SearchUiState.Loading)
+        // タイトル名の更新
+        _conditionState.update { currentState ->
+            currentState.copy(
+                pokemonTypeName = typeNumber.toString().convertToJaTypeName()
+            )
+        }
+        runCatching {
+            withContext(Dispatchers.IO) {
+                // DBから該当する一覧を取得（全カラム）
+                val roomResult = searchTypeListRepository.searchByTypeNumber(typeNumber)
+                // maxPageを更新
+                _conditionState.update { currentState ->
+                    currentState.copy(
+                        maxPage = roomResult.size.div(DISPLAY_UI_DATA_LIST_ITEM).plus(1).toString()
+                    )
+                }
+
+                // 不足データがあればAPIから取得してDB保存する
+                roomResult.forEach { pokemon ->
+                    if (pokemon.japaneseName.isNullOrEmpty()) {
+                        //APIから取得
+                        val japaneseName =
+                            searchRepository.getPokemonSpecies(pokemon.speciesNumber).names.firstOrNull { name -> name.language.name == "ja" }?.name
+                                ?: ""
+
+                        // DBに保存
+                        searchTypeListRepository.updateJapaneseName(
+                            pokemonNumber = pokemon.pokemonNumber,
+                            japaneseName = japaneseName
+                        )
+                    }
+                }
+                // 取得したListを20件ずつのListに変換
+                val updateRoomResult = searchTypeListRepository.searchByTypeNumber(typeNumber)
+                // 20件ずつに分割したリストを生成
+                val chunkedList = updateRoomResult.map { item ->
+                    PokemonListUiData(
+                        pokemonNumber = item.pokemonNumber,
+                        displayName = item.japaneseName ?: "",
+                        imageUrl = item.imageUrl,
+                        speciesNumber = item.speciesNumber.toString()
+                    )
+                }.chunked(DISPLAY_UI_DATA_LIST_ITEM).toMutableList()
+
+                // 最後のリストを調整
+                val lastChunkList = chunkedList.lastOrNull()?.take(DISPLAY_UI_DATA_LIST_ITEM)
+                if (lastChunkList != null) {
+                    chunkedList[chunkedList.size.minus(1)] = lastChunkList
+                }
+                responseUiDataList.clear()
+                responseUiDataList += chunkedList
+            }
+        }.onSuccess {
+            // 該当するListを表示
+            showUiDataList()
+            searchedTypeList.add(
+                SearchedType(
+                    typeNumber = typeNumber,
+                    isFetched = true
+                )
+            )
+        }.onFailure {
+            send(SearchUiEvent.Error(it))
+            _uiState.emit(SearchUiState.ResultError)
+            Log.d("test", "e[showPokemonTypeList]：$it")
+        }
+    }
+
+    /**
+     * 指定したpagePositionのリストを表示
+     */
+    private fun showUiDataList(pagePosition: Int = 0) = viewModelScope.launch {
         _conditionState.update { currentState ->
             currentState.copy(
                 pagePosition = pagePosition,
-                isFirst = true
+                isFirst = true,
             )
         }
 
-        // 未取得の場合のみ取得しにいく
-        if (!displayUiDataList[pagePosition].isFetched) {
-            _uiState.emit(SearchUiState.Loading)
-            urlList.onEach { url ->
-                val pokemonNumber = Uri.parse(url).lastPathSegment
-                async {
-                    pokemonNumber?.let { number ->
-                        // ポケモンのパーソナル情報を取得
-                        personalDataList.add(searchRepository.getPokemonPersonalData(number.toInt()))
-
-                        // ポケモンの特性取得のためのNumberを取得
-                        val speciesNumber =
-                            Uri.parse(personalDataList[personalDataList.lastIndex].species.url).lastPathSegment
-
-                        // ポケモンの特性を取得
-                        speciesNumber?.let {
-                            speciesList.add(searchRepository.getPokemonSpecies(it.toInt()))
-                        }
-                    }
-                }.await()
-            }
-
-            // 取得した情報を表示用listに保存
-            responseUiDataList[pagePosition].onEachIndexed { index, responseUiData ->
-                responseUiData.apply {
-                    imageUrl =
-                        personalDataList[index].sprites.other.officialArtwork.imgUrl ?: "".apply {
-
-                        }
-                    displayName =
-                        speciesList[index].names.firstOrNull { name -> name.language.name == "ja" }?.name
-                            ?: ""
-                    pokemonNumber = speciesList[index].id
+        _uiState.emit(
+            SearchUiState.Fetched(
+                searchList = if (responseUiDataList.size != 0) {
+                    responseUiDataList[pagePosition]
+                } else {
+                    emptyList()
                 }
-            }
-            displayUiDataList[pagePosition] = displayUiDataList[pagePosition].copy(
-                list = responseUiDataList[pagePosition],
-                isFetched = true
             )
-        }
-        _uiState.emit(SearchUiState.Fetched(searchList = displayUiDataList[pagePosition].list))
+        )
     }
 
     /**
@@ -193,7 +270,7 @@ class SearchViewModel(private val searchRepository: SearchRepository) : ViewMode
 
     override fun onClickNext() {
         val pagePosition = conditionState.value.pagePosition
-        if (pagePosition < responseUiDataList.size.minus(1)) updateDisplayUiDataList(
+        if (pagePosition < responseUiDataList.size.minus(1)) showUiDataList(
             conditionState.value.pagePosition.plus(
                 1
             )
@@ -202,14 +279,14 @@ class SearchViewModel(private val searchRepository: SearchRepository) : ViewMode
 
     override fun onClickBack() {
         val pagePosition = conditionState.value.pagePosition
-        if (pagePosition > 0) updateDisplayUiDataList(pagePosition.minus(1))
+        if (pagePosition > 0) showUiDataList(pagePosition.minus(1))
     }
 }
 
 /**
  * 検索一覧表示用
  */
-data class SearchedListData(
-    val list: List<PokemonListUiData>,
+data class SearchedType(
+    val typeNumber: Int,
     val isFetched: Boolean
 )


### PR DESCRIPTION

## 対応内容

* search type listテーブルを追加し、初回でタイプ一覧の一部をDB保存するよう変更
* タイプ一覧表示時はDBの情報を確認し、必要な時だけAPIを叩く処理に変更
* 詳細画面表示時、DBを確認して必要な時だけAPIを叩く処理に変更
* 詳細画面遷移の仕方を変更　→ BottomNavigationViewで引数を渡す


※見た目に関わる変更なし