### PR TITLE
タイプ検索一覧表示の性能改善

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -92,4 +92,6 @@ dependencies {
     annotationProcessor "androidx.room:room-compiler:2.5.2"
     // splashscreen
     implementation "androidx.core:core-splashscreen:1.0.0-alpha01"
+    // ImmutableList
+    implementation "org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.5"
 }

--- a/app/src/main/java/com/example/pokebook/data/searchType/SearchTypeList.kt
+++ b/app/src/main/java/com/example/pokebook/data/searchType/SearchTypeList.kt
@@ -5,6 +5,7 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.example.pokebook.model.PokemonListItem
 import com.example.pokebook.model.PokemonTypeSearchResult
+import com.example.pokebook.ui.viewModel.Home.PokemonListUiData
 
 /**
  * 初回起動時に検索タイプ一覧を取得するためのエンティティ
@@ -24,7 +25,7 @@ data class SearchTypeList(
 )
 
 /**
- * PokemonTypeSearchResult -> SearchTypeList
+ * PokemonTypeSearchResult -> List<SearchTypeList>
  */
 fun PokemonTypeSearchResult.toSearchTypeList(): List<SearchTypeList> {
     val resultList = mutableListOf<SearchTypeList>()
@@ -43,4 +44,16 @@ fun PokemonTypeSearchResult.toSearchTypeList(): List<SearchTypeList> {
         )
     }
     return resultList
+}
+
+/**
+ * List<PokemonListUiData> -> List<SearchTypeList>
+ */
+fun List<PokemonListUiData>.toSearchTypeListByPokemonListUiData(): List<SearchTypeList> {
+    return this.map { item ->
+        SearchTypeList(
+            japaneseName = item.displayName,
+            pokemonNumber = item.pokemonNumber
+        )
+    }
 }

--- a/app/src/main/java/com/example/pokebook/ui/AppViewModelProvider.kt
+++ b/app/src/main/java/com/example/pokebook/ui/AppViewModelProvider.kt
@@ -29,7 +29,8 @@ object AppViewModelProvider {
         initializer {
             SearchViewModel(
                 pokemonApplication().container.searchRepository,
-                pokemonApplication().container.searchTypeListRepository
+                pokemonApplication().container.searchTypeListRepository,
+                pokemonApplication().container.pokemonDataRepository
             )
         }
         initializer {

--- a/app/src/main/java/com/example/pokebook/ui/screen/Navigation/BottomNavigationScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/Navigation/BottomNavigationScreen.kt
@@ -138,19 +138,13 @@ fun NavGraphBuilder.searchGraph(
                     navController.navigate("${SearchScreen.PokemonDetailScreenByName.route}/$pokemonName")
                 },
                 onClickSearchTypeButton = { typeNumber ->
-                    navController.navigate("${SearchScreen.PokemonListScreen.route}/$typeNumber")
+                    navController.navigate("${SearchScreen.PokemonListScreen.route}")
+                    searchViewModel.onLoad(typeNumber)
                 },
             )
         }
-        composable(
-            route = "${SearchScreen.PokemonListScreen.route}/{typeNumber}",
-            arguments = listOf(
-                navArgument("typeNumber") { type = NavType.IntType }
-            )
-        ) { backStackEntry ->
-            val typeNumber = backStackEntry.arguments?.getInt("typeNumber") ?: 0
+        composable(SearchScreen.PokemonListScreen.route) {
             SearchListScreen(
-                typeNumber = typeNumber,
                 searchViewModel = searchViewModel,
                 onClickCard = { speciesNumber, pokemonNumber ->
                     navController.navigate("${SearchScreen.PokemonDetailScreenByNumber.route}/$speciesNumber/$pokemonNumber")

--- a/app/src/main/java/com/example/pokebook/ui/screen/SearchListScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/SearchListScreen.kt
@@ -2,6 +2,7 @@ package com.example.pokebook.ui.screen
 
 import android.annotation.SuppressLint
 import android.util.Log
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -28,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -35,12 +37,12 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.example.pokebook.R
-import com.example.pokebook.ui.viewModel.Detail.PokemonDetailViewModel
 import com.example.pokebook.ui.viewModel.Home.PokemonListUiData
 import com.example.pokebook.ui.viewModel.Search.SearchConditionState
 import com.example.pokebook.ui.viewModel.Search.SearchUiEvent
 import com.example.pokebook.ui.viewModel.Search.SearchUiState
 import com.example.pokebook.ui.viewModel.Search.SearchViewModel
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
@@ -49,13 +51,10 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun SearchListScreen(
-    typeNumber: Int,
     searchViewModel: SearchViewModel,
     onClickCard: (Int, Int) -> Unit,
     onClickBackSearchScreen: () -> Unit
 ) {
-    searchViewModel.showPokemonTypeList(typeNumber)
-
     SearchListScreen(
         uiState = searchViewModel.uiState,
         uiStateEvent = searchViewModel.uiEvent,
@@ -89,6 +88,8 @@ private fun SearchListScreen(
     val state by uiState.collectAsStateWithLifecycle()
     val uiEvent by uiStateEvent.collectAsStateWithLifecycle(initialValue = null)
     val searchWord = conditionState.value.pokemonTypeName
+    val lazyGridState = rememberLazyGridState()
+    val coroutineScope = rememberCoroutineScope()
 
     when (uiEvent) {
         is SearchUiEvent.Error -> {
@@ -119,7 +120,9 @@ private fun SearchListScreen(
                     onClickCard = onClickCard,
                     updateButtonStates = updateButtonStates,
                     updateIsFirst = updateIsFirst,
-                    onClickBackSearchScreen = onClickBackSearchScreen
+                    onClickBackSearchScreen = onClickBackSearchScreen,
+                    lazyGridState = lazyGridState,
+                    coroutineScope = coroutineScope
                 )
             }
         }
@@ -151,7 +154,7 @@ private fun SearchListScreen(
 
 @Composable
 private fun SearchListScreen(
-    pokemonUiDataList: List<PokemonListUiData>,
+    pokemonUiDataList: ImmutableList<PokemonListUiData>,
     isFirst: Boolean,
     searchWord: String,
     pagePosition: Int,
@@ -162,14 +165,13 @@ private fun SearchListScreen(
     updateButtonStates: (Boolean, Boolean) -> Unit,
     updateIsFirst: (Boolean) -> Unit,
     onClickBackSearchScreen: () -> Unit,
+    lazyGridState: LazyGridState,
+    coroutineScope: CoroutineScope
 ) {
     Column(
         modifier = Modifier
             .background(MaterialTheme.colorScheme.background),
     ) {
-        val lazyGridState = rememberLazyGridState()
-        val coroutineScope = rememberCoroutineScope()
-
         DefaultHeader(
             pagePosition = pagePosition,
             title = String.format(
@@ -204,7 +206,7 @@ private fun SearchListScreen(
 
 @Composable
 private fun PokeTypeList(
-    pokemonUiDataList: List<PokemonListUiData>,
+    pokemonUiDataList: ImmutableList<PokemonListUiData>,
     isFirst: Boolean,
     onClickCard: (Int, Int) -> Unit,
     updateIsFirst: (Boolean) -> Unit,
@@ -225,7 +227,7 @@ private fun PokeTypeList(
         modifier = Modifier
             .fillMaxSize()
     ) {
-        items(pokemonUiDataList) { listItem ->
+        items(pokemonUiDataList.toMutableList()) { listItem ->
             PokeTypeCard(
                 pokemon = listItem,
                 onClickCard = onClickCard,

--- a/app/src/main/java/com/example/pokebook/ui/screen/SearchListScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/SearchListScreen.kt
@@ -248,10 +248,19 @@ private fun PokeTypeCard(
         elevation = CardDefaults.cardElevation(4.dp),
         onClick = { onClickCard.invoke(pokemon.speciesNumber?.toInt() ?: 0, pokemon.pokemonNumber) }
     ) {
-        if (!pokemon.imageUrl.isNullOrEmpty()) {
-            Box(
-                contentAlignment = Alignment.BottomCenter
-            ) {
+        Box(
+            contentAlignment = Alignment.BottomCenter
+        ) {
+            if (pokemon.imageUrl.isNullOrEmpty()) {
+                Image(
+                    painter = painterResource(id = R.drawable.no_image),
+                    modifier = Modifier
+                        .size(200.dp)
+                        .padding(bottom = 20.dp),
+                    contentScale = ContentScale.Crop,
+                    contentDescription = null
+                )
+            } else {
                 AsyncImage(
                     model = ImageRequest.Builder(context = LocalContext.current)
                         .data(pokemon.imageUrl)
@@ -263,27 +272,27 @@ private fun PokeTypeCard(
                     contentScale = ContentScale.Crop,
                     contentDescription = null
                 )
-                Text(
-                    text = String.format(
-                        stringResource(R.string.pokemon_name),
-                        pokemon.pokemonNumber,
-                        pokemon.displayName
-                    ),
-                    fontSize = 13.sp,
-                    color = MaterialTheme.colorScheme.onSecondary,
-                    modifier = Modifier
-                        .shadow(
-                            elevation = 1.dp,
-                            shape = RoundedCornerShape(8.dp)
-                        )
-                        .padding(bottom = 2.dp)
-                        .background(
-                            color = MaterialTheme.colorScheme.secondary,
-                            shape = RoundedCornerShape(8.dp)
-                        )
-                        .padding(3.dp)
-                )
             }
+            Text(
+                text = String.format(
+                    stringResource(R.string.pokemon_name),
+                    pokemon.pokemonNumber,
+                    pokemon.displayName
+                ),
+                fontSize = 13.sp,
+                color = MaterialTheme.colorScheme.onSecondary,
+                modifier = Modifier
+                    .shadow(
+                        elevation = 1.dp,
+                        shape = RoundedCornerShape(8.dp)
+                    )
+                    .padding(bottom = 2.dp)
+                    .background(
+                        color = MaterialTheme.colorScheme.secondary,
+                        shape = RoundedCornerShape(8.dp)
+                    )
+                    .padding(3.dp)
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Search/SearchState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Search/SearchState.kt
@@ -1,6 +1,7 @@
 package com.example.pokebook.ui.viewModel.Search
 
 import com.example.pokebook.ui.viewModel.Home.PokemonListUiData
+import kotlinx.collections.immutable.ImmutableList
 import java.util.UUID
 
 /**
@@ -9,7 +10,7 @@ import java.util.UUID
 sealed class SearchUiState {
     object Loading : SearchUiState()
     data class Fetched(
-        val searchList: List<PokemonListUiData>
+        val searchList: ImmutableList<PokemonListUiData>
     ) : SearchUiState()
 
     object InitialState : SearchUiState()

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Search/SearchViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Search/SearchViewModel.kt
@@ -46,7 +46,8 @@ const val TYPE_SHADOW = "10002"
 
 class SearchViewModel(
     private val searchRepository: ApiSearchRepository,
-    private val searchTypeListRepository: SearchTypeListRepository
+    private val searchTypeListRepository: SearchTypeListRepository,
+    private val pokemonDataRepository: PokemonDataRepository
 ) : ViewModel(), DefaultHeader {
     private var _uiState: MutableStateFlow<SearchUiState> =
         MutableStateFlow(SearchUiState.InitialState)

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Search/SearchViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Search/SearchViewModel.kt
@@ -7,13 +7,18 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.pokebook.data.pokemonData.PokemonDataRepository
+import com.example.pokebook.data.searchType.SearchTypeList
 import com.example.pokebook.data.searchType.SearchTypeListRepository
 import com.example.pokebook.data.searchType.toSearchTypeList
+import com.example.pokebook.data.searchType.toSearchTypeListByPokemonListUiData
 import com.example.pokebook.repository.ApiSearchRepository
 import com.example.pokebook.ui.screen.convertToJaTypeName
 import com.example.pokebook.ui.viewModel.DefaultHeader
 import com.example.pokebook.ui.viewModel.Home.PokemonListUiData
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.mutate
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -21,6 +26,12 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.collections.immutable.toImmutableSet
+import kotlinx.collections.immutable.toPersistentList
+import okhttp3.internal.immutableListOf
+import okhttp3.internal.toImmutableList
 
 const val DISPLAY_UI_DATA_LIST_ITEM = 20
 const val TYPE_NORMAL = "1"
@@ -57,9 +68,6 @@ class SearchViewModel(
         MutableStateFlow(SearchConditionState())
     val conditionState = _conditionState.asStateFlow()
 
-    // APIから取得したタイプ別一覧を格納するリスト
-    private val responseUiDataList = mutableListOf<List<PokemonListUiData>>()
-
     private val _uiEvent: MutableStateFlow<List<SearchUiEvent>> = MutableStateFlow(listOf())
     val uiEvent: Flow<SearchUiEvent?>
         get() = _uiEvent.map { it.firstOrNull() }
@@ -77,8 +85,8 @@ class SearchViewModel(
     // splash画面起動して良いかどうか
     private val _isReady: MutableLiveData<Boolean> = MutableLiveData(false)
     val isReady: LiveData<Boolean> get() = _isReady
-
-    private val searchedTypeList = mutableListOf<SearchedType>()
+    private val responseUiDataList = mutableListOf<PokemonListUiData>()
+    private var showUiDataList: List<List<PokemonListUiData>> = emptyList()
 
     /**
      * 初回起動でAPIからType一覧を取得してDBに保存
@@ -146,14 +154,23 @@ class SearchViewModel(
     }
 
     /**
+     * タイプ別ボタンが押された時に呼ばれる
+     */
+    fun onLoad(typeNumber: Int) {
+        // タイプボタン押下した時は必ず１ページ目を表示
+        _conditionState.update { currentState ->
+            currentState.copy(
+                pagePosition = 0
+            )
+        }
+        // type一覧取得
+        getPokemonTypeList(typeNumber)
+    }
+
+    /**
      * DBから指定されたType一覧を取得して表示
      */
-    fun showPokemonTypeList(typeNumber: Int) = viewModelScope.launch {
-        // リスト取得済みかどうかを確認
-        searchedTypeList.forEach { item ->
-            if (item.typeNumber == typeNumber && item.isFetched) return@launch
-        }
-
+    private fun getPokemonTypeList(typeNumber: Int) = viewModelScope.launch {
         _uiState.emit(SearchUiState.Loading)
         // タイトル名の更新
         _conditionState.update { currentState ->
@@ -162,88 +179,121 @@ class SearchViewModel(
             )
         }
         runCatching {
+            // 表示に関わるListを初期化
+            showUiDataList = mutableListOf()
+
             withContext(Dispatchers.IO) {
-                // DBから該当する一覧を取得（全カラム）
+                // DBから該当するタイプ一覧を取得
                 val roomResult = searchTypeListRepository.searchByTypeNumber(typeNumber)
+                    .chunked(DISPLAY_UI_DATA_LIST_ITEM)
+                // 表示するデータがない場合は早期return
+                if (roomResult.isEmpty()) {
+                    showPokemonTypeList()
+                    return@withContext
+                }
                 // maxPageを更新
                 _conditionState.update { currentState ->
                     currentState.copy(
-                        maxPage = roomResult.size.div(DISPLAY_UI_DATA_LIST_ITEM).plus(1).toString()
+                        maxPage = roomResult.size.toString()
                     )
                 }
-
-                // 不足データがあればAPIから取得してDB保存する
-                roomResult.forEach { pokemon ->
-                    if (pokemon.japaneseName.isNullOrEmpty()) {
-                        //APIから取得
-                        val japaneseName =
-                            searchRepository.getPokemonSpecies(pokemon.speciesNumber).names.firstOrNull { name -> name.language.name == "ja" }?.name
-                                ?: ""
-
-                        // DBに保存
-                        searchTypeListRepository.updateJapaneseName(
-                            pokemonNumber = pokemon.pokemonNumber,
-                            japaneseName = japaneseName
-                        )
+                var japaneseName = ""
+                roomResult.forEach { childList ->
+                    responseUiDataList.clear()
+                    childList.forEach { pokemon ->
+                        if (pokemon.japaneseName.isNullOrEmpty()) {
+                            // pokemonDataテーブルに存在していない時だけAPIを叩く
+                            japaneseName =
+                                if (pokemonDataRepository.searchById(pokemon.pokemonNumber) != null) {
+                                    pokemonDataRepository.searchById(pokemon.pokemonNumber).japaneseName
+                                } else {
+                                    searchRepository.getPokemonSpecies(pokemon.speciesNumber).names.firstOrNull { name -> name.language.name == "ja" }?.name
+                                        ?: ""
+                                }
+                            responseUiDataList.add(
+                                PokemonListUiData(
+                                    pokemonNumber = pokemon.pokemonNumber,
+                                    displayName = japaneseName,
+                                    imageUrl = pokemon.imageUrl ?: "",
+                                    speciesNumber = pokemon.speciesNumber.toString()
+                                )
+                            )
+                        } else {
+                            // DBに存在している時はDBの情報を取得
+                            responseUiDataList.add(
+                                PokemonListUiData(
+                                    pokemonNumber = pokemon.pokemonNumber,
+                                    displayName = pokemon.japaneseName,
+                                    imageUrl = pokemon.imageUrl ?: "",
+                                    speciesNumber = pokemon.speciesNumber.toString()
+                                )
+                            )
+                        }
                     }
+                    val mutableList = showUiDataList.toMutableList()
+                    mutableList.add(responseUiDataList.toImmutableList())
+                    showUiDataList = mutableList
+                    showPokemonTypeList()
                 }
-                // 取得したListを20件ずつのListに変換
-                val updateRoomResult = searchTypeListRepository.searchByTypeNumber(typeNumber)
-                // 20件ずつに分割したリストを生成
-                val chunkedList = updateRoomResult.map { item ->
-                    PokemonListUiData(
-                        pokemonNumber = item.pokemonNumber,
-                        displayName = item.japaneseName ?: "",
-                        imageUrl = item.imageUrl,
-                        speciesNumber = item.speciesNumber.toString()
-                    )
-                }.chunked(DISPLAY_UI_DATA_LIST_ITEM).toMutableList()
-
-                // 最後のリストを調整
-                val lastChunkList = chunkedList.lastOrNull()?.take(DISPLAY_UI_DATA_LIST_ITEM)
-                if (lastChunkList != null) {
-                    chunkedList[chunkedList.size.minus(1)] = lastChunkList
-                }
-                responseUiDataList.clear()
-                responseUiDataList += chunkedList
             }
         }.onSuccess {
-            // 該当するListを表示
-            showUiDataList()
-            searchedTypeList.add(
-                SearchedType(
-                    typeNumber = typeNumber,
-                    isFetched = true
-                )
-            )
+            // DB保存
+            saveSearchTypeResult(showUiDataList)
         }.onFailure {
             send(SearchUiEvent.Error(it))
             _uiState.emit(SearchUiState.ResultError)
-            Log.d("test", "e[showPokemonTypeList]：$it")
+            Log.d("test", "e[getPokemonTypeList]：$it")
         }
     }
 
     /**
      * 指定したpagePositionのリストを表示
      */
-    private fun showUiDataList(pagePosition: Int = 0) = viewModelScope.launch {
+    private fun showPokemonTypeList(pagePosition: Int = 0) = viewModelScope.launch {
         _conditionState.update { currentState ->
             currentState.copy(
                 pagePosition = pagePosition,
-                isFirst = true,
             )
         }
 
-        _uiState.emit(
-            SearchUiState.Fetched(
-                searchList = if (responseUiDataList.size != 0) {
-                    responseUiDataList[pagePosition]
-                } else {
-                    emptyList()
-                }
+        try {
+            _uiState.emit(
+                SearchUiState.Fetched(
+                    searchList = if (showUiDataList.isNotEmpty()) {
+                        showUiDataList[conditionState.value.pagePosition].toImmutableSet()
+                            .toImmutableList() // TODO 謎。いつか調べたい。一発で.toImmutableList()で変換したい
+                    } else {
+                        persistentListOf()
+                    }
+                )
             )
-        )
+        } catch (e: Exception) {
+            Log.d("test", "e[showPokemonTypeList]:$e")
+        }
     }
+
+    /**
+     * 作成したタイプ別一覧をDBに保存
+     */
+    private fun saveSearchTypeResult(resultList: List<List<PokemonListUiData>>) =
+        viewModelScope.launch {
+            var saveList: List<List<SearchTypeList>>
+            withContext(Dispatchers.IO) {
+                // DB保存用データ型に変換
+                saveList = resultList.toMutableList().map { childList ->
+                    childList.toSearchTypeListByPokemonListUiData()
+                }
+                // DBに保存
+                saveList.forEach { childList ->
+                    childList.forEach { pokemon ->
+                        searchTypeListRepository.updateJapaneseName(
+                            pokemonNumber = pokemon.pokemonNumber,
+                            japaneseName = pokemon.japaneseName ?: ""
+                        )
+                    }
+                }
+            }
+        }
 
     /**
      * どのボタンが押下されたかを更新
@@ -270,8 +320,9 @@ class SearchViewModel(
     }
 
     override fun onClickNext() {
+        updateIsFirst(true)
         val pagePosition = conditionState.value.pagePosition
-        if (pagePosition < responseUiDataList.size.minus(1)) showUiDataList(
+        if (pagePosition < responseUiDataList.size.minus(1)) showPokemonTypeList(
             conditionState.value.pagePosition.plus(
                 1
             )
@@ -279,15 +330,8 @@ class SearchViewModel(
     }
 
     override fun onClickBack() {
+        updateIsFirst(true)
         val pagePosition = conditionState.value.pagePosition
-        if (pagePosition > 0) showUiDataList(pagePosition.minus(1))
+        if (pagePosition > 0) showPokemonTypeList(pagePosition.minus(1))
     }
 }
-
-/**
- * 検索一覧表示用
- */
-data class SearchedType(
-    val typeNumber: Int,
-    val isFetched: Boolean
-)


### PR DESCRIPTION
## 対応内容

タイプ検索表示がタイミングによってエラーを起こしたり、取得時間が異常に長いことがあたため全体的なロジックを見直した

* composableに渡すListをImmutable型に変更
* タイプ検索一覧表示時のロジックを見直し
　→表示用データが全て揃ってから表示させていたが、１ページ目が揃った時点で表示するよう変更
　　残りの表示用データ作成やDB保存はバックグラウンドで実施
* 画面遷移時に叩きたいメソッドについてタイミングを変更



## スクリーンショット

| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/65d2633a-81c1-4cb3-a4d9-bd32cc93b603" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/7fba0b0f-5ace-4c0e-865f-7c63ecfcaac9" width="200px"/>|


