### PR TITLE
各タブの詳細画面遷移ロジックを見直し

### DIFF
--- a/app/src/main/java/com/example/pokebook/ui/activity/MainActivity.kt
+++ b/app/src/main/java/com/example/pokebook/ui/activity/MainActivity.kt
@@ -39,14 +39,14 @@ class MainActivity : ComponentActivity() {
         installSplashScreen()
 
         val content: View = findViewById(android.R.id.content)
-        var isReady=false
+        var isReady = false
 
         // 初回起動時のみ実施
         if (!AppLaunchChecker.hasStartedFromLauncher(this)) {
             mainViewModel.readJson()
             searchViewModel.getPokemonTypeList()
             AppLaunchChecker.onActivityCreate(this)
-        }else{
+        } else {
             isReady = true
         }
 

--- a/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
@@ -1,7 +1,6 @@
 package com.example.pokebook.ui.screen
 
 import android.annotation.SuppressLint
-import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -31,7 +30,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -42,7 +40,6 @@ import com.example.pokebook.ui.viewModel.Home.HomeScreenConditionState
 import com.example.pokebook.ui.viewModel.Home.PokemonListUiData
 import com.example.pokebook.ui.viewModel.Home.HomeUiState
 import com.example.pokebook.ui.viewModel.Home.HomeViewModel
-import com.example.pokebook.ui.viewModel.Detail.PokemonDetailViewModel
 import com.example.pokebook.ui.viewModel.Home.HomeUiEvent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -220,9 +217,7 @@ fun PokeCard(
     Card(
         modifier = modifier.padding(8.dp),
         elevation = cardElevation(4.dp),
-        onClick = {
-            Log.d("test","詳細画面を開く時の情報：$pokemon")
-            onClickCard.invoke(pokemon.speciesNumber?.toInt() ?: 0, pokemon.pokemonNumber) }
+        onClick = { onClickCard.invoke(pokemon.speciesNumber?.toInt() ?: 0, pokemon.pokemonNumber) }
     ) {
         Box(
             contentAlignment = Alignment.BottomCenter

--- a/app/src/main/java/com/example/pokebook/ui/screen/LikeEntryScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/LikeEntryScreen.kt
@@ -38,14 +38,11 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.example.pokebook.R
-import com.example.pokebook.ui.viewModel.Detail.PokemonDetailViewModel
-import com.example.pokebook.ui.viewModel.Home.PokemonListUiData
 
 import com.example.pokebook.ui.viewModel.Like.LikeDetails
 import com.example.pokebook.ui.viewModel.Like.LikeEntryViewModel
 import com.example.pokebook.ui.viewModel.Like.LikeUiEvent
 import com.example.pokebook.ui.viewModel.Like.LikeUiState
-import com.example.pokebook.ui.viewModel.Like.toPokemonListUiDataByLikeDetails
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch

--- a/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
@@ -49,7 +49,6 @@ import com.example.pokebook.ui.viewModel.Detail.PokemonDetailScreenUiData
 import com.example.pokebook.ui.viewModel.Detail.PokemonDetailUiEvent
 import com.example.pokebook.ui.viewModel.Detail.PokemonDetailUiState
 import com.example.pokebook.ui.viewModel.Detail.PokemonDetailViewModel
-import com.example.pokebook.ui.viewModel.Home.PokemonListUiData
 import com.example.pokebook.ui.viewModel.Like.LikeDetails
 import com.example.pokebook.ui.viewModel.Like.LikeEntryViewModel
 import com.example.pokebook.ui.viewModel.Like.toLikeDetails
@@ -59,21 +58,10 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun PokemonDetailScreen(
-    speciesNumber: Int = 0,
-    pokemonNumber: Int? = null,
-    pokemonName: String? = "",
     likeEntryViewModel: LikeEntryViewModel,
     pokemonDetailViewModel: PokemonDetailViewModel = viewModel(factory = AppViewModelProvider.Factory),
     onClickBackButton: () -> Unit
 ) {
-    if (pokemonNumber != null) {
-        pokemonDetailViewModel.getPokemonSpeciesById(pokemonNumber, speciesNumber)
-    } else if (!pokemonName.isNullOrEmpty()) {
-        pokemonDetailViewModel.getPokemonSpeciesByName(pokemonName)
-    } else {
-        // 何もしない
-    }
-
     PokemonDetailScreen(
         uiState = pokemonDetailViewModel.uiState,
         uiEvent = pokemonDetailViewModel.uiEvent,

--- a/app/src/main/java/com/example/pokebook/ui/screen/SearchScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/SearchScreen.kt
@@ -31,8 +31,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.pokebook.R
-import com.example.pokebook.ui.viewModel.Detail.PokemonDetailViewModel
-import com.example.pokebook.ui.viewModel.Search.SearchViewModel
 
 @SuppressLint("StateFlowValueCalledInComposition")
 @Composable

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Search/SearchViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Search/SearchViewModel.kt
@@ -121,6 +121,7 @@ class SearchViewModel(
                     searchRepository.getPokemonByType(typeNumber).toSearchTypeList()
                 // DBに保存
                 searchTypeListRepository.insert(typeList)
+                _isReady.postValue(true)
                 withContext(Dispatchers.IO) {
                     // DBから該当する一覧を取得（全カラム）
                     val roomResult = searchTypeListRepository.searchByTypeNumber(typeNumber.toInt())
@@ -146,7 +147,7 @@ class SearchViewModel(
                 }
             }
         }.onSuccess {
-            _isReady.postValue(true)
+            // 何もしない
         }.onFailure {
             _isReady.postValue(false)
             Log.d("error", "e[getPokemonTypeList]：$it") // TODO　いずれエラーダイアログ遷移


### PR DESCRIPTION
## 対応内容

* PokemonDetailViewModelインスタンスの生成タイミングと生成方法を変更
* 各タブから詳細画面遷移する処理を修正。不要な引数の受け渡しを削除
→ 詳細画面表示時のちらつき修正





