### PR TITLE
HomeViewModelのインスタンス生成をより狭いスコープで行うよう修正

### DIFF
--- a/app/src/main/java/com/example/pokebook/ui/screen/Navigation/BottomNavigationScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/Navigation/BottomNavigationScreen.kt
@@ -49,7 +49,6 @@ private fun NavigationHost(
     startDestination: String = BottomNavItems.Home.route,
     navController: NavHostController = rememberNavController(),
     searchViewModel: SearchViewModel = viewModel(factory = AppViewModelProvider.Factory),
-    homeViewModel: HomeViewModel = viewModel(factory = AppViewModelProvider.Factory),
     likeEntryViewModel: LikeEntryViewModel = viewModel(factory = AppViewModelProvider.Factory),
     @SuppressLint("ModifierParameter") modifier: Modifier = Modifier
 ) {
@@ -78,7 +77,6 @@ private fun NavigationHost(
     ) {
         homeGraph(
             navController = navController,
-            homeViewModel = homeViewModel,
             likeEntryViewModel = likeEntryViewModel,
             pokemonDetailViewModel = homeDetailViewModel
         )
@@ -105,7 +103,6 @@ private fun NavigationHost(
  */
 fun NavGraphBuilder.homeGraph(
     navController: NavController,
-    homeViewModel: HomeViewModel,
     pokemonDetailViewModel: PokemonDetailViewModel,
     likeEntryViewModel: LikeEntryViewModel
 ) {
@@ -114,6 +111,7 @@ fun NavGraphBuilder.homeGraph(
         route = BottomNavItems.Home.route
     ) {
         composable(HomeScreen.PokemonListScreen.route) {
+            val homeViewModel: HomeViewModel = viewModel(factory = AppViewModelProvider.Factory)
             HomeScreen(
                 homeViewModel = homeViewModel,
                 onClickCard = { speciesNumber, pokemonNumber ->


### PR DESCRIPTION
## 対応内容

* HomeViewModelのインスタンス生成タイミングをより狭いスコープ内で行うよう変更
　→　初回起動時に一覧表示ができない事象修正


## スクリーンショット

| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/6eb6cc97-b6ac-46fa-b781-2756642f8434" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/43e5f57d-af57-4b57-bfd9-07a5a0909887" width="200px"/>|
