### PR TITLE
詳細画面のレイアウトを微修正

### DIFF
--- a/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
@@ -149,38 +149,27 @@ private fun PokemonDetailScreen(
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
-            .verticalScroll(
-                state = rememberScrollState(),
-                reverseScrolling = true
-            )
     ) {
-        Image(
-            imageVector = ImageVector.vectorResource(
-                id = if (isSystemInDarkTheme()) R.drawable.arrow_back_fillf else R.drawable.arrow_back_fill0
-            ),
-            contentDescription = null,
-            modifier = Modifier
-                .align(Alignment.Start)
-                .clickable {
-                    onClickBackButton.invoke()
-                }
-        )
-        TitleImage(
-            pokemon = uiData,
-            type = uiData.type.firstOrNull() ?: "",
-            updateIsLike = updateIsLike,
-            deleteLike = deleteLike,
-            saveLike = saveLike,
-            checkIfRoomLike = checkIfRoomLike
-        )
-        Column(
-            verticalArrangement = Arrangement.spacedBy(20.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier
-                .background(MaterialTheme.colorScheme.background)
-                .fillMaxSize()
-                .padding(6.dp)
-        ) {
+        Column {
+            Image(
+                imageVector = ImageVector.vectorResource(
+                    id = if (isSystemInDarkTheme()) R.drawable.arrow_back_fillf else R.drawable.arrow_back_fill0
+                ),
+                contentDescription = null,
+                modifier = Modifier
+                    .align(Alignment.Start)
+                    .clickable {
+                        onClickBackButton.invoke()
+                    }
+            )
+            TitleImage(
+                pokemon = uiData,
+                type = uiData.type.firstOrNull() ?: "",
+                updateIsLike = updateIsLike,
+                deleteLike = deleteLike,
+                saveLike = saveLike,
+                checkIfRoomLike = checkIfRoomLike
+            )
             AutoSizeableText(
                 text = String.format(
                     stringResource(id = R.string.pokemon_name),
@@ -191,6 +180,20 @@ private fun PokemonDetailScreen(
                 modifier = modifier
                     .align(Alignment.CenterHorizontally)
             )
+        }
+
+        Column(
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.background)
+                .fillMaxSize()
+                .padding(6.dp)
+                .verticalScroll(
+                    state = rememberScrollState(),
+                    reverseScrolling = true
+                )
+        ) {
             Text(
                 text = uiData.description,
                 fontSize = 15.sp,


### PR DESCRIPTION

## 対応内容

* 詳細画面にて、戻る、画像、名前が固定され、それ以下がスクロールできるよう修正


## スクリーンショット

| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/2f5bae79-a18d-4da9-bf4a-9254cba81b5a" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/e093f245-45da-41d0-b09c-c8bbbd1964e9" width="200px"/>|

