### PR TITLE
検索画面のタイプ一覧にて、２ページ目以降スクロールが先頭に戻らない事象を修正

### DIFF
--- a/app/src/main/java/com/example/pokebook/ui/screen/Navigation/BottomNavigationScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/Navigation/BottomNavigationScreen.kt
@@ -175,6 +175,8 @@ fun NavGraphBuilder.searchGraph(
                         pokemonNumber = pokemonNumber,
                         speciesNumber = speciesNumber
                     )
+                    // 詳細画面遷移の際はスクロール位置を保持しておく
+                    searchViewModel.updateIsFirst(false)
                 },
                 onClickBackSearchScreen = { navController.navigateUp() }
             )

--- a/app/src/main/java/com/example/pokebook/ui/screen/SearchListScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/SearchListScreen.kt
@@ -1,7 +1,6 @@
 package com.example.pokebook.ui.screen
 
 import android.annotation.SuppressLint
-import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -22,9 +21,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -111,7 +108,7 @@ private fun SearchListScreen(
             } else {
                 SearchListScreen(
                     pokemonUiDataList = (state as SearchUiState.Fetched).searchList,
-                    isFirst = conditionState.value.isFirst,
+                    isFirst = conditionState.value.isScrollTop,
                     searchWord = searchWord,
                     pagePosition = conditionState.value.pagePosition,
                     maxPage = conditionState.value.maxPage,

--- a/app/src/main/java/com/example/pokebook/ui/screen/SearchListScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/SearchListScreen.kt
@@ -22,7 +22,9 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -64,7 +66,6 @@ fun SearchListScreen(
         onClickNext = searchViewModel::onClickNext,
         onClickCard = onClickCard,
         updateButtonStates = searchViewModel::updateButtonStates,
-        updateIsFirst = searchViewModel::updateIsFirst,
         onClickBackSearchScreen = onClickBackSearchScreen,
         onClickBackButton = onClickBackSearchScreen
     )
@@ -81,7 +82,6 @@ private fun SearchListScreen(
     onClickNext: () -> Unit,
     onClickCard: (Int, Int) -> Unit,
     updateButtonStates: (Boolean, Boolean) -> Unit,
-    updateIsFirst: (Boolean) -> Unit,
     onClickBackSearchScreen: () -> Unit,
     onClickBackButton: () -> Unit
 ) {
@@ -119,7 +119,6 @@ private fun SearchListScreen(
                     onClickNext = onClickNext,
                     onClickCard = onClickCard,
                     updateButtonStates = updateButtonStates,
-                    updateIsFirst = updateIsFirst,
                     onClickBackSearchScreen = onClickBackSearchScreen,
                     lazyGridState = lazyGridState,
                     coroutineScope = coroutineScope
@@ -163,7 +162,6 @@ private fun SearchListScreen(
     onClickNext: () -> Unit,
     onClickCard: (Int, Int) -> Unit,
     updateButtonStates: (Boolean, Boolean) -> Unit,
-    updateIsFirst: (Boolean) -> Unit,
     onClickBackSearchScreen: () -> Unit,
     lazyGridState: LazyGridState,
     coroutineScope: CoroutineScope
@@ -196,8 +194,8 @@ private fun SearchListScreen(
         PokeTypeList(
             pokemonUiDataList = pokemonUiDataList,
             isFirst = isFirst,
+            pagePosition = pagePosition,
             onClickCard = onClickCard,
-            updateIsFirst = updateIsFirst,
             lazyGridState = lazyGridState,
             coroutineScope = coroutineScope
         )
@@ -208,19 +206,19 @@ private fun SearchListScreen(
 private fun PokeTypeList(
     pokemonUiDataList: ImmutableList<PokemonListUiData>,
     isFirst: Boolean,
+    pagePosition:Int,
     onClickCard: (Int, Int) -> Unit,
-    updateIsFirst: (Boolean) -> Unit,
     lazyGridState: LazyGridState,
     coroutineScope: CoroutineScope
 ) {
-    LaunchedEffect(lazyGridState) {
-        coroutineScope.launch {
-            if (isFirst) {
+    if (isFirst) {
+        LaunchedEffect(pagePosition) {
+            coroutineScope.launch {
                 lazyGridState.scrollToItem(0)
-                updateIsFirst.invoke(false)
             }
         }
     }
+
     LazyVerticalGrid(
         state = lazyGridState,
         columns = GridCells.Adaptive(minSize = 150.dp),

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Search/SearchState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Search/SearchState.kt
@@ -25,7 +25,7 @@ data class SearchConditionState(
     val isNextButton: Boolean = false,
     val pagePosition: Int = 0,
     val maxPage: String = "",
-    val isFirst: Boolean = true
+    val isScrollTop: Boolean = true
 )
 
 /**

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Search/SearchState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Search/SearchState.kt
@@ -14,7 +14,7 @@ sealed class SearchUiState {
     ) : SearchUiState()
 
     object InitialState : SearchUiState()
-    object ResultError: SearchUiState()
+    object ResultError : SearchUiState()
 }
 
 data class SearchConditionState(
@@ -25,7 +25,7 @@ data class SearchConditionState(
     val isNextButton: Boolean = false,
     val pagePosition: Int = 0,
     val maxPage: String = "",
-    val isFirst:Boolean = true
+    val isFirst: Boolean = true
 )
 
 /**

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Search/SearchViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Search/SearchViewModel.kt
@@ -173,6 +173,7 @@ class SearchViewModel(
      */
     private fun getPokemonTypeList(typeNumber: Int) = viewModelScope.launch {
         _uiState.emit(SearchUiState.Loading)
+        updateIsFirst(true)
         // タイトル名の更新
         _conditionState.update { currentState ->
             currentState.copy(

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Search/SearchViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Search/SearchViewModel.kt
@@ -15,10 +15,7 @@ import com.example.pokebook.repository.ApiSearchRepository
 import com.example.pokebook.ui.screen.convertToJaTypeName
 import com.example.pokebook.ui.viewModel.DefaultHeader
 import com.example.pokebook.ui.viewModel.Home.PokemonListUiData
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.mutate
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -29,8 +26,6 @@ import kotlinx.coroutines.withContext
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toImmutableSet
-import kotlinx.collections.immutable.toPersistentList
-import okhttp3.internal.immutableListOf
 import okhttp3.internal.toImmutableList
 
 const val DISPLAY_UI_DATA_LIST_ITEM = 20
@@ -315,9 +310,9 @@ class SearchViewModel(
     /**
      * 初回取得時かどうか
      */
-    fun updateIsFirst(isFirst: Boolean) {
+    fun updateIsFirst(isScrollTop: Boolean) {
         _conditionState.update { current ->
-            current.copy(isFirst = isFirst)
+            current.copy(isScrollTop = isScrollTop)
         }
     }
 


### PR DESCRIPTION
## 対応内容

* LaunchedEffectが変更を認識してくれないとそれ以降の処理が走らないため、引数にpagePositionを渡すよう修正
* 詳細画面遷移時にisScrollTopをfalseにすることで、一覧画面へ戻った時にスクロール位置を保持できるよう修正


## スクリーンショット

＜一覧のページ切り替え＞
| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/bba1a4a4-7c3c-4401-a8f0-60559186312d" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/be1b489a-7a13-48d8-9563-9372365c8cc5" width="200px"/>|

＜詳細から一覧へ＞
| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/9ef4d32f-c7b3-4dc1-8de6-a8a515e2d7cc" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/9bc5a145-fbca-4860-9abe-fd200d3c434b" width="200px"/>|


