### PR TITLE
一度取得済みのHome一覧リストがページを切り替えた時に先頭から表示されない事象を修正

### DIFF
--- a/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
@@ -60,7 +60,6 @@ fun HomeScreen(
         onClickNext = homeViewModel::onClickNext,
         onClickBack = homeViewModel::onClickBack,
         onClickCard = onClickCard,
-        updateIsFirst = homeViewModel::updateIsFirst,
         onClickRetryGetList = homeViewModel::getPokemonList
     )
 }
@@ -75,13 +74,11 @@ private fun HomeScreen(
     onClickNext: () -> Unit,
     onClickBack: () -> Unit,
     onClickCard: (Int, Int) -> Unit,
-    updateIsFirst: (Boolean) -> Unit,
     onClickRetryGetList: () -> Unit
 ) {
     val state by uiState.collectAsStateWithLifecycle()
     val uiEvent by uiEvent.collectAsStateWithLifecycle(initialValue = null)
     val lazyGridState = rememberLazyGridState()
-    val coroutineScope = rememberCoroutineScope()
 
     when (uiEvent) {
         is HomeUiEvent.Error -> {
@@ -99,13 +96,11 @@ private fun HomeScreen(
             PokeList(
                 pagePosition = homeUiConditionState.value.pagePosition,
                 pokemonUiDataList = (state as HomeUiState.Fetched).uiDataList,
-                isFirst = homeUiConditionState.value.isScrollTop,
+                isScrollTop = homeUiConditionState.value.isScrollTop,
                 onClickNext = onClickNext,
                 onClickBack = onClickBack,
                 onClickCard = onClickCard,
-                updateIsFirst = updateIsFirst,
                 lazyGridState = lazyGridState,
-                coroutineScope = coroutineScope
             )
         }
 
@@ -140,13 +135,11 @@ private fun HomeScreen(
 private fun PokeList(
     pagePosition: Int,
     pokemonUiDataList: List<PokemonListUiData>,
-    isFirst: Boolean,
+    isScrollTop: Boolean,
     onClickNext: () -> Unit,
     onClickBack: () -> Unit,
     onClickCard: (Int, Int) -> Unit,
-    updateIsFirst: (Boolean) -> Unit,
     lazyGridState: LazyGridState,
-    coroutineScope: CoroutineScope
 ) {
     Column(
         modifier = Modifier
@@ -165,11 +158,10 @@ private fun PokeList(
         )
         PokeList(
             pokemonUiDataList = pokemonUiDataList,
-            isFirst = isFirst,
+            isScrollTop = isScrollTop,
+            pagePosition = pagePosition,
             onClickCard = onClickCard,
-            updateIsFirst = updateIsFirst,
             lazyGridState = lazyGridState,
-            coroutineScope = coroutineScope
         )
     }
 }
@@ -180,18 +172,15 @@ private fun PokeList(
 @Composable
 fun PokeList(
     pokemonUiDataList: List<PokemonListUiData>,
-    isFirst: Boolean,
+    isScrollTop: Boolean,
+    pagePosition:Int,
     onClickCard: (Int, Int) -> Unit,
-    updateIsFirst: (Boolean) -> Unit,
     lazyGridState: LazyGridState,
-    coroutineScope: CoroutineScope
 ) {
-    LaunchedEffect(lazyGridState) {
-        coroutineScope.launch {
-            if (isFirst) {
-                lazyGridState.scrollToItem(0)
-                updateIsFirst.invoke(false)
-            }
+    // スクロールを先頭に戻すかどうか
+    if (isScrollTop) {
+        LaunchedEffect(pagePosition) {
+            lazyGridState.scrollToItem(0)
         }
     }
     LazyVerticalGrid(

--- a/app/src/main/java/com/example/pokebook/ui/screen/Navigation/BottomNavigationScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/Navigation/BottomNavigationScreen.kt
@@ -120,6 +120,8 @@ fun NavGraphBuilder.homeGraph(
                         pokemonNumber = pokemonNumber,
                         speciesNumber = speciesNumber
                     )
+                    // 詳細画面遷移の際はスクロール位置を保持しておく
+                    homeViewModel.updateIsFirst(false)
                 }
             )
         }

--- a/app/src/main/java/com/example/pokebook/ui/screen/SearchListScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/SearchListScreen.kt
@@ -86,7 +86,6 @@ private fun SearchListScreen(
     val uiEvent by uiStateEvent.collectAsStateWithLifecycle(initialValue = null)
     val searchWord = conditionState.value.pokemonTypeName
     val lazyGridState = rememberLazyGridState()
-    val coroutineScope = rememberCoroutineScope()
 
     when (uiEvent) {
         is SearchUiEvent.Error -> {
@@ -118,7 +117,6 @@ private fun SearchListScreen(
                     updateButtonStates = updateButtonStates,
                     onClickBackSearchScreen = onClickBackSearchScreen,
                     lazyGridState = lazyGridState,
-                    coroutineScope = coroutineScope
                 )
             }
         }
@@ -161,7 +159,6 @@ private fun SearchListScreen(
     updateButtonStates: (Boolean, Boolean) -> Unit,
     onClickBackSearchScreen: () -> Unit,
     lazyGridState: LazyGridState,
-    coroutineScope: CoroutineScope
 ) {
     Column(
         modifier = Modifier
@@ -194,7 +191,6 @@ private fun SearchListScreen(
             pagePosition = pagePosition,
             onClickCard = onClickCard,
             lazyGridState = lazyGridState,
-            coroutineScope = coroutineScope
         )
     }
 }
@@ -206,13 +202,10 @@ private fun PokeTypeList(
     pagePosition:Int,
     onClickCard: (Int, Int) -> Unit,
     lazyGridState: LazyGridState,
-    coroutineScope: CoroutineScope
 ) {
     if (isFirst) {
         LaunchedEffect(pagePosition) {
-            coroutineScope.launch {
                 lazyGridState.scrollToItem(0)
-            }
         }
     }
 

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Home/HomeViewModel.kt
@@ -133,6 +133,7 @@ class HomeViewModel(
      * 「次へ」ボタン押下してポケモンリスト取得
      */
     override fun onClickNext() {
+        updateIsFirst(true)
         _conditionState.update { currentState ->
             currentState.copy(
                 pagePosition = conditionState.value.pagePosition.plus(1)
@@ -145,6 +146,7 @@ class HomeViewModel(
      * 「戻る」ボタン押下して一つ前のポケモンリストを取得
      */
     override fun onClickBack() {
+        updateIsFirst(true)
         _conditionState.update { currentState ->
             currentState.copy(
                 pagePosition = conditionState.value.pagePosition.minus(1)
@@ -154,7 +156,7 @@ class HomeViewModel(
     }
 
     /**
-     * 初回取得時かどうか
+     * スクロールを先頭に戻すかどうか
      */
     fun updateIsFirst(isScrollTop: Boolean) {
         _conditionState.update { current ->

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Search/SearchViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Search/SearchViewModel.kt
@@ -308,7 +308,7 @@ class SearchViewModel(
     }
 
     /**
-     * 初回取得時かどうか
+     * スクロールを先頭に戻すかどうか
      */
     fun updateIsFirst(isScrollTop: Boolean) {
         _conditionState.update { current ->


### PR DESCRIPTION

## 対応内容

* LaunchedEffectが変更を認識してくれないとそれ以降の処理が走らないため、引数にpagePositionを眺めよう修正
* 詳細画面遷移時にScrollTopをfalseにすることで、一覧画面へ戻ったスクロール位置を保持できるよう修正


## スクリーンショット
＜一覧のページ切り替え＞
| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/7852b109-88ce-4af1-94c1-35311e3b49e7" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/e1fb324c-6ef2-4da0-8b4e-254fd5ad8bd4" width="200px"/>|

