### PR TITLE
home画面でページ切り替え時に表示がズレる事象を修正

### DIFF
--- a/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/HomeScreen.kt
@@ -1,6 +1,7 @@
 package com.example.pokebook.ui.screen
 
 import android.annotation.SuppressLint
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -41,6 +42,7 @@ import com.example.pokebook.ui.viewModel.Home.PokemonListUiData
 import com.example.pokebook.ui.viewModel.Home.HomeUiState
 import com.example.pokebook.ui.viewModel.Home.HomeViewModel
 import com.example.pokebook.ui.viewModel.Home.HomeUiEvent
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
@@ -134,7 +136,7 @@ private fun HomeScreen(
 @Composable
 private fun PokeList(
     pagePosition: Int,
-    pokemonUiDataList: List<PokemonListUiData>,
+    pokemonUiDataList: ImmutableList<PokemonListUiData>,
     isScrollTop: Boolean,
     onClickNext: () -> Unit,
     onClickBack: () -> Unit,
@@ -171,7 +173,7 @@ private fun PokeList(
  */
 @Composable
 fun PokeList(
-    pokemonUiDataList: List<PokemonListUiData>,
+    pokemonUiDataList: ImmutableList<PokemonListUiData>,
     isScrollTop: Boolean,
     pagePosition:Int,
     onClickCard: (Int, Int) -> Unit,

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Home/HomeState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Home/HomeState.kt
@@ -2,6 +2,7 @@ package com.example.pokebook.ui.viewModel.Home
 
 import android.os.Parcel
 import android.os.Parcelable
+import kotlinx.collections.immutable.ImmutableList
 import java.util.UUID
 
 /**
@@ -10,7 +11,7 @@ import java.util.UUID
 sealed class HomeUiState {
     object Loading : HomeUiState()
     data class Fetched(
-        val uiDataList: MutableList<PokemonListUiData>
+        val uiDataList: ImmutableList<PokemonListUiData>
     ) : HomeUiState()
 
     object InitialState : HomeUiState()

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Home/HomeViewModel.kt
@@ -9,6 +9,7 @@ import com.example.pokebook.data.pokemonData.pokemonPersonalDataToPokemonData
 import com.example.pokebook.model.PokemonPersonalData
 import com.example.pokebook.repository.HomeRepository
 import com.example.pokebook.ui.viewModel.DefaultHeader
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -88,7 +89,7 @@ class HomeViewModel(
                 }
             }
         }.onSuccess {
-            _uiState.emit(HomeUiState.Fetched(uiDataList = uiDataList))
+            _uiState.emit(HomeUiState.Fetched(uiDataList = uiDataList.toImmutableList()))
         }.onFailure {
             send(HomeUiEvent.Error(it))
             _uiState.emit(HomeUiState.ResultError)


### PR DESCRIPTION

## 対応内容

* Home画面表示周りのListをImmutableListに変更


## スクリーンショット

| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/172340cc-3fa8-4557-a093-48244e230e1c" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/c78da3cd-3847-49ce-aaca-fc5ca4c4774d" width="200px"/>|

