### PR TITLE
ポケモン詳細画面で進化系譜を表示、遷移できるよう機能追加を行った

### DIFF
--- a/app/src/main/java/com/example/pokebook/data/AppContainer.kt
+++ b/app/src/main/java/com/example/pokebook/data/AppContainer.kt
@@ -13,6 +13,8 @@ import com.example.pokebook.repository.DefaultSearchRepository
 import com.example.pokebook.repository.HomeRepository
 import com.example.pokebook.repository.PokemonDetailRepository
 import com.example.pokebook.repository.ApiSearchRepository
+import com.example.pokebook.repository.DefaultEvolutionChainRepository
+import com.example.pokebook.repository.EvolutionChainRepository
 
 /**
  * 依存性注入のためのアプリコンテナ
@@ -24,6 +26,7 @@ interface AppContainer {
     val pokemonDetailRepository: PokemonDetailRepository
     val homeRepository: HomeRepository
     val searchTypeListRepository: SearchTypeListRepository
+    val evolutionChainRepository: EvolutionChainRepository
 }
 
 /**
@@ -50,5 +53,8 @@ class AppDataContainer(private val context: Context) : AppContainer {
     }
     override val searchTypeListRepository: SearchTypeListRepository by lazy {
         OfflineSearchTypeListRepository(PokemonDatabase.getDatabase(context).searchTypeListDao())
+    }
+    override val evolutionChainRepository: EvolutionChainRepository by lazy {
+        DefaultEvolutionChainRepository()
     }
 }

--- a/app/src/main/java/com/example/pokebook/data/pokemonData/OfflinePokemonDataRepository.kt
+++ b/app/src/main/java/com/example/pokebook/data/pokemonData/OfflinePokemonDataRepository.kt
@@ -44,7 +44,8 @@ class OfflinePokemonDataRepository(private val pokemonDataDao: PokemonDataDao) :
         imageUrl: String?,
         genus: String?,
         type: List<String>?,
-        speciesNumber: String?
+        speciesNumber: String?,
+        evolutionChainNumber:String?
     ) = pokemonDataDao.updatePokemonAllData(
         pokemonNumber = pokemonNumber,
         englishName = englishName,
@@ -57,7 +58,8 @@ class OfflinePokemonDataRepository(private val pokemonDataDao: PokemonDataDao) :
         imageUrl = imageUrl,
         genus = genus,
         type = type,
-        speciesNumber = speciesNumber
+        speciesNumber = speciesNumber,
+        evolutionChainNumber = evolutionChainNumber
     )
 
     override suspend fun searchById(id: Int): PokemonData = pokemonDataDao.searchById(id)

--- a/app/src/main/java/com/example/pokebook/data/pokemonData/OfflinePokemonDataRepository.kt
+++ b/app/src/main/java/com/example/pokebook/data/pokemonData/OfflinePokemonDataRepository.kt
@@ -1,10 +1,5 @@
 package com.example.pokebook.data.pokemonData
 
-import android.util.Log
-import com.example.pokebook.data.pokemonData.PokemonData
-import com.example.pokebook.data.pokemonData.PokemonDataDao
-import com.example.pokebook.data.pokemonData.PokemonDataRepository
-
 class OfflinePokemonDataRepository(private val pokemonDataDao: PokemonDataDao) :
     PokemonDataRepository {
     override fun getAllItemsStream(): List<PokemonData> = pokemonDataDao.getAllItems()
@@ -16,7 +11,7 @@ class OfflinePokemonDataRepository(private val pokemonDataDao: PokemonDataDao) :
 
     override suspend fun updateItem(pokemon: PokemonData) = pokemonDataDao.update(pokemon)
     override suspend fun searchPokemonByKeyword(keyword: String): PokemonData =
-        pokemonDataDao.searchByJapaneseName(keyword)
+        pokemonDataDao.searchPokemonByKeyword(keyword)
 
     override suspend fun getAllItemsBetweenIds(startId: Int, endId: Int): List<PokemonData> =
         pokemonDataDao.getAllItemsBetweenIds(startId, endId)

--- a/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonData.kt
+++ b/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonData.kt
@@ -30,7 +30,8 @@ data class PokemonData(
     val defense: Int? = 0,
     val speed: Int? = 0,
     val imageUrl: String? = "",
-    val speciesNumber: String? = ""
+    val speciesNumber: String? = "",
+    val evolutionChainNumber:String? = ""
 )
 
 /**

--- a/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonDataDao.kt
+++ b/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonDataDao.kt
@@ -44,7 +44,7 @@ interface PokemonDataDao {
     suspend fun updatePokemonData(id: Int, imageUrl: String, speciesNumber: String?)
 
     // 指定したpokemonNumberの必要なカラムを更新
-    @Query("UPDATE pokemonData SET englishName = :englishName, japaneseName = :japaneseName, description = :description,hp = :hp, attack = :attack, defense = :defense, speed = :speed, imageUrl = :imageUrl,speciesNumber = :speciesNumber,genus=:genus,type=:type WHERE id = :pokemonNumber")
+    @Query("UPDATE pokemonData SET englishName = :englishName, japaneseName = :japaneseName, description = :description,hp = :hp, attack = :attack, defense = :defense, speed = :speed, imageUrl = :imageUrl,speciesNumber = :speciesNumber,genus=:genus,type=:type,evolutionChainNumber=:evolutionChainNumber WHERE id = :pokemonNumber")
     suspend fun updatePokemonAllData(
         pokemonNumber: Int? = null,
         englishName: String? = null,
@@ -57,6 +57,7 @@ interface PokemonDataDao {
         imageUrl: String? = null,
         genus: String?,
         type: List<String>?,
-        speciesNumber: String?
+        speciesNumber: String?,
+        evolutionChainNumber: String?
     )
 }

--- a/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonDataDao.kt
+++ b/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonDataDao.kt
@@ -7,7 +7,6 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.TypeConverters
 import androidx.room.Update
-import com.example.pokebook.data.pokemonData.PokemonData
 
 @Dao
 @TypeConverters(StringListTypeConverter::class)
@@ -28,8 +27,8 @@ interface PokemonDataDao {
     fun getAllItems(): List<PokemonData>
 
     // japaneseName完全一致の検索
-    @Query("SELECT * FROM pokemonData WHERE japaneseName = :keyword")
-    fun searchByJapaneseName(keyword: String): PokemonData
+    @Query("SELECT * FROM pokemonData WHERE LOWER(japaneseName) = LOWER(:keyword) OR LOWER(englishName) = LOWER(:keyword)")
+    fun searchPokemonByKeyword(keyword: String): PokemonData
 
     // id完全一致の検索
     @Query("SELECT * FROM pokemonData WHERE id = :id")

--- a/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonDataDao.kt
+++ b/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonDataDao.kt
@@ -26,7 +26,7 @@ interface PokemonDataDao {
     @Query("SELECT * from pokemonData ORDER BY japaneseName ASC")
     fun getAllItems(): List<PokemonData>
 
-    // japaneseName完全一致の検索
+    // japaneseName or englishName　の検索（大文字小文字区別なし）
     @Query("SELECT * FROM pokemonData WHERE LOWER(japaneseName) = LOWER(:keyword) OR LOWER(englishName) = LOWER(:keyword)")
     fun searchPokemonByKeyword(keyword: String): PokemonData
 

--- a/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonDataRepository.kt
+++ b/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonDataRepository.kt
@@ -49,8 +49,8 @@ interface PokemonDataRepository {
      * 指定したIDの必要なカラムを更新
      */
     suspend fun updatePokemonAllData(
-        id: Int?=null,
-        pokemonNumber:Int? = null,
+        id: Int? = null,
+        pokemonNumber: Int? = null,
         englishName: String? = null,
         japaneseName: String? = null,
         description: String? = null,
@@ -58,10 +58,11 @@ interface PokemonDataRepository {
         attack: Int? = null,
         defense: Int? = null,
         speed: Int? = null,
-        imageUrl: String? =null,
+        imageUrl: String? = null,
         genus: String? = null,
         type: List<String>? = null,
-        speciesNumber: String? = null
+        speciesNumber: String? = null,
+        evolutionChainNumber: String? = null
     )
 
 

--- a/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonDataRepository.kt
+++ b/app/src/main/java/com/example/pokebook/data/pokemonData/PokemonDataRepository.kt
@@ -27,7 +27,7 @@ interface PokemonDataRepository {
     suspend fun updateItem(pokemon: PokemonData)
 
     /**
-     * 指定されたjapaneseNameを検索
+     * 指定されたjapaneseName　or englishNameで検索
      */
     suspend fun searchPokemonByKeyword(keyword: String): PokemonData
 

--- a/app/src/main/java/com/example/pokebook/model/EvolutionChain.kt
+++ b/app/src/main/java/com/example/pokebook/model/EvolutionChain.kt
@@ -1,0 +1,41 @@
+package com.example.pokebook.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+
+/**
+ * 進化系の情報を取得
+ */
+@Serializable
+data class EvolutionChain(
+    val chain: Chain? =null
+)
+
+@Serializable
+data class Chain(
+    @SerialName("evolves_to")
+    val evolves: List<Evolves>?,
+    @SerialName("species")
+    val basePokemon: EvolvesSpecies?
+)
+
+@Serializable
+data class Evolves(
+    @SerialName("evolves_to")
+    val evolves: List<NextEvolves>?,
+    @SerialName("species")
+    val nextGeneration: EvolvesSpecies?
+)
+
+@Serializable
+data class NextEvolves(
+    @SerialName("species")
+    val lastGeneration: EvolvesSpecies
+)
+
+@Serializable
+data class EvolvesSpecies(
+    val name: String?,
+    val url: String?
+)

--- a/app/src/main/java/com/example/pokebook/model/PokemonPersonalData.kt
+++ b/app/src/main/java/com/example/pokebook/model/PokemonPersonalData.kt
@@ -80,7 +80,10 @@ data class PokemonSpecies(
     /** ポケモンID */
     val id: Int,
     /** 属性 */
-    val genera: List<Genera>
+    val genera: List<Genera>,
+    /** 進化系 */
+    @SerialName("evolution_chain")
+    val evolutionChain: EvolutionChainUrl
 )
 
 @Serializable
@@ -106,6 +109,11 @@ data class FlavorTextEntries(
 data class Genera(
     val genus: String,
     val language: Language
+)
+
+@Serializable
+data class EvolutionChainUrl(
+    val url: String
 )
 
 enum class StatType(val type: String) {

--- a/app/src/main/java/com/example/pokebook/network/PokeApiService.kt
+++ b/app/src/main/java/com/example/pokebook/network/PokeApiService.kt
@@ -1,5 +1,6 @@
 package com.example.pokebook.network
 
+import com.example.pokebook.model.EvolutionChain
 import com.example.pokebook.model.Pokemon
 import com.example.pokebook.model.PokemonPersonalData
 import com.example.pokebook.model.PokemonSpecies
@@ -61,6 +62,12 @@ interface PokeApiService {
      */
     @GET("type/{path}")
     suspend fun getPokemonByType(@Path("path") typeNumber: String): PokemonTypeSearchResult
+
+    /**
+     * ポケモン進化系譜取得
+     */
+    @GET("evolution-chain/{path}")
+    suspend fun getPokemonEvolutionChain(@Path("path") evolutionNumber: String): EvolutionChain
 }
 
 object PokeApi {

--- a/app/src/main/java/com/example/pokebook/network/PokeApiService.kt
+++ b/app/src/main/java/com/example/pokebook/network/PokeApiService.kt
@@ -46,10 +46,16 @@ interface PokeApiService {
     ): Pokemon
 
     /**
-     * ポケモン個体情報取得
+     * ポケモン個体情報取得(ID検索)
      */
     @GET("pokemon/{path}")
     suspend fun getPokemonPersonalData(@Path("path") number: Int): PokemonPersonalData
+
+    /**
+     * ポケモン個体情報取得(name検索)
+     */
+    @GET("pokemon/{path}")
+    suspend fun getPokemonPersonalData(@Path("path") name: String): PokemonPersonalData
 
     /**
      * ポケモン個体説明取得

--- a/app/src/main/java/com/example/pokebook/repository/EvolutionChainRepository.kt
+++ b/app/src/main/java/com/example/pokebook/repository/EvolutionChainRepository.kt
@@ -1,0 +1,17 @@
+package com.example.pokebook.repository
+
+import com.example.pokebook.model.EvolutionChain
+import com.example.pokebook.network.PokeApi
+import retrofit2.http.Path
+
+interface EvolutionChainRepository {
+    suspend fun getPokemonEvolutionChain(@Path("path") evolutionNumber: String): EvolutionChain
+}
+
+class DefaultEvolutionChainRepository : EvolutionChainRepository {
+    override suspend fun getPokemonEvolutionChain(evolutionNumber: String): EvolutionChain {
+        return PokeApi.retrofitService.getPokemonEvolutionChain(
+            evolutionNumber = evolutionNumber
+        )
+    }
+}

--- a/app/src/main/java/com/example/pokebook/repository/PokemonDetailRepository.kt
+++ b/app/src/main/java/com/example/pokebook/repository/PokemonDetailRepository.kt
@@ -7,12 +7,17 @@ import retrofit2.http.Path
 
 interface PokemonDetailRepository {
     suspend fun getPokemonPersonalData(@Path("path") number: Int): PokemonPersonalData
+    suspend fun getPokemonPersonalData(@Path("path") name: String): PokemonPersonalData
     suspend fun getPokemonSpecies(@Path("path") number: Int): PokemonSpecies
 }
 
-class DefaultPokemonDetailRepository: PokemonDetailRepository{
+class DefaultPokemonDetailRepository : PokemonDetailRepository {
     override suspend fun getPokemonPersonalData(number: Int): PokemonPersonalData {
         return PokeApi.retrofitService.getPokemonPersonalData(number)
+    }
+
+    override suspend fun getPokemonPersonalData(name: String): PokemonPersonalData {
+        return PokeApi.retrofitService.getPokemonPersonalData(name)
     }
 
     override suspend fun getPokemonSpecies(number: Int): PokemonSpecies {

--- a/app/src/main/java/com/example/pokebook/ui/AppViewModelProvider.kt
+++ b/app/src/main/java/com/example/pokebook/ui/AppViewModelProvider.kt
@@ -42,7 +42,6 @@ object AppViewModelProvider {
         initializer {
             PokemonDetailViewModel(
                 pokemonApplication().container.pokemonDetailRepository,
-                pokemonApplication().container.pokemonDataRepository,
                 pokemonApplication().container.likesRepository,
                 pokemonApplication().container.pokemonDataRepository,
                 pokemonApplication().container.evolutionChainRepository

--- a/app/src/main/java/com/example/pokebook/ui/AppViewModelProvider.kt
+++ b/app/src/main/java/com/example/pokebook/ui/AppViewModelProvider.kt
@@ -44,7 +44,8 @@ object AppViewModelProvider {
                 pokemonApplication().container.pokemonDetailRepository,
                 pokemonApplication().container.pokemonDataRepository,
                 pokemonApplication().container.likesRepository,
-                pokemonApplication().container.pokemonDataRepository
+                pokemonApplication().container.pokemonDataRepository,
+                pokemonApplication().container.evolutionChainRepository
             )
         }
     }

--- a/app/src/main/java/com/example/pokebook/ui/screen/Navigation/BottomNavigationScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/Navigation/BottomNavigationScreen.kt
@@ -115,13 +115,13 @@ fun NavGraphBuilder.homeGraph(
             HomeScreen(
                 homeViewModel = homeViewModel,
                 onClickCard = { speciesNumber, pokemonNumber ->
-                    navController.navigate(HomeScreen.PokemonDetailScreen.route)
                     pokemonDetailViewModel.getPokemonSpeciesById(
                         pokemonNumber = pokemonNumber,
                         speciesNumber = speciesNumber
                     )
                     // 詳細画面遷移の際はスクロール位置を保持しておく
                     homeViewModel.updateIsFirst(false)
+                    navController.navigate(HomeScreen.PokemonDetailScreen.route)
                 }
             )
         }
@@ -132,8 +132,8 @@ fun NavGraphBuilder.homeGraph(
                 likeEntryViewModel = likeEntryViewModel,
                 onClickBackButton = { navController.navigateUp() },
                 onClickEvolution = { pokemonName ->
-                    navController.navigate(HomeScreen.PokemonEvolutionDetailScreen.route)
                     pokemonDetailViewModel.getPokemonSpeciesByName(pokemonName)
+                    navController.navigate(HomeScreen.PokemonEvolutionDetailScreen.route)
                 },
                 pokemonDetailViewModel = pokemonDetailViewModel
             )
@@ -145,8 +145,8 @@ fun NavGraphBuilder.homeGraph(
                 likeEntryViewModel = likeEntryViewModel,
                 onClickBackButton = { navController.navigate(HomeScreen.PokemonListScreen.route) }, // TODO 一旦TOPにタブのTOPに戻すが、遷移前の詳細画面を保持してそこに戻す処理に変更予定
                 onClickEvolution = { pokemonName ->
-                    navController.navigate(HomeScreen.PokemonEvolutionDetailScreen.route)
                     pokemonDetailViewModel.getPokemonSpeciesByName(pokemonName)
+                    navController.navigate(HomeScreen.PokemonEvolutionDetailScreen.route)
                 },
                 pokemonDetailViewModel = pokemonDetailViewModel
             )
@@ -170,18 +170,18 @@ fun NavGraphBuilder.searchGraph(
         composable(SearchScreen.SearchTopScreen.route) {
             SearchScreen(
                 onClickSearchNumber = { pokemonNumber ->
-                    navController.navigate(SearchScreen.PokemonDetailScreenByNumber.route)
                     pokemonDetailViewModel.getPokemonSpeciesById(
                         pokemonNumber = pokemonNumber
                     )
+                    navController.navigate(SearchScreen.PokemonDetailScreenByNumber.route)
                 },
                 onClickSearchName = { pokemonName ->
-                    navController.navigate(SearchScreen.PokemonDetailScreenByName.route)
                     pokemonDetailViewModel.getPokemonSpeciesByName(pokemonName)
+                    navController.navigate(SearchScreen.PokemonDetailScreenByName.route)
                 },
                 onClickSearchTypeButton = { typeNumber ->
-                    navController.navigate(SearchScreen.PokemonListScreen.route)
                     searchViewModel.onLoad(typeNumber)
+                    navController.navigate(SearchScreen.PokemonListScreen.route)
                 }
             )
         }
@@ -189,13 +189,13 @@ fun NavGraphBuilder.searchGraph(
             SearchListScreen(
                 searchViewModel = searchViewModel,
                 onClickCard = { speciesNumber, pokemonNumber ->
-                    navController.navigate(SearchScreen.PokemonDetailScreenByNumber.route)
                     pokemonDetailViewModel.getPokemonSpeciesById(
                         pokemonNumber = pokemonNumber,
                         speciesNumber = speciesNumber
                     )
                     // 詳細画面遷移の際はスクロール位置を保持しておく
                     searchViewModel.updateIsFirst(false)
+                    navController.navigate(SearchScreen.PokemonDetailScreenByNumber.route)
                 },
                 onClickBackSearchScreen = { navController.navigateUp() }
             )
@@ -218,8 +218,8 @@ fun NavGraphBuilder.searchGraph(
                 pokemonDetailViewModel = pokemonDetailViewModel,
                 onClickBackButton = { navController.navigateUp() },
                 onClickEvolution = { pokemonName ->
-                    navController.navigate(SearchScreen.PokemonEvolutionDetailScreen.route)
                     pokemonDetailViewModel.getPokemonSpeciesByName(pokemonName)
+                    navController.navigate(SearchScreen.PokemonEvolutionDetailScreen.route)
                 }
             )
         }
@@ -227,10 +227,10 @@ fun NavGraphBuilder.searchGraph(
             PokemonDetailScreen(
                 likeEntryViewModel = likeEntryViewModel,
                 pokemonDetailViewModel = pokemonDetailViewModel,
-                onClickBackButton = { navController.navigate(SearchScreen.PokemonListScreen.route) }, // TODO 一旦タブのtopに戻す
+                onClickBackButton = { navController.navigate(SearchScreen.SearchTopScreen.route) }, // TODO 一旦タブのtopに戻す
                 onClickEvolution = { pokemonName ->
-                    navController.navigate(SearchScreen.PokemonEvolutionDetailScreen.route)
                     pokemonDetailViewModel.getPokemonSpeciesByName(pokemonName)
+                    navController.navigate(SearchScreen.PokemonEvolutionDetailScreen.route)
                 },
             )
         }
@@ -269,8 +269,8 @@ fun NavGraphBuilder.likeGraph(
                 pokemonDetailViewModel = pokemonDetailViewModel,
                 onClickBackButton = { navController.navigateUp() },
                 onClickEvolution = { pokemonName ->
-                    navController.navigate(LikeScreen.PokemonEvolutionDetailScreen.route)
                     pokemonDetailViewModel.getPokemonSpeciesByName(pokemonName)
+                    navController.navigate(LikeScreen.PokemonEvolutionDetailScreen.route)
                 },
             )
         }
@@ -280,8 +280,8 @@ fun NavGraphBuilder.likeGraph(
                 pokemonDetailViewModel = pokemonDetailViewModel,
                 onClickBackButton = { navController.navigate(LikeScreen.LikeListScreen.route) }, // TODO 一旦タブのtopに戻す
                 onClickEvolution = { pokemonName ->
-                    navController.navigate(LikeScreen.PokemonEvolutionDetailScreen.route)
                     pokemonDetailViewModel.getPokemonSpeciesByName(pokemonName)
+                    navController.navigate(LikeScreen.PokemonEvolutionDetailScreen.route)
                 }
             )
         }

--- a/app/src/main/java/com/example/pokebook/ui/screen/Navigation/BottomNavigationScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/Navigation/BottomNavigationScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.Text
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -38,6 +39,7 @@ import com.example.pokebook.ui.viewModel.Home.HomeViewModel
 import com.example.pokebook.ui.viewModel.Like.LikeEntryViewModel
 import com.example.pokebook.ui.viewModel.Search.SearchViewModel
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
+import kotlinx.coroutines.launch
 
 /**
  * NavHost に宛先を設定する
@@ -213,12 +215,15 @@ fun NavGraphBuilder.searchGraph(
             )
         }
         composable(route = SearchScreen.PokemonDetailScreenByNumber.route) {
+            val coroutine = rememberCoroutineScope()
             PokemonDetailScreen(
                 likeEntryViewModel = likeEntryViewModel,
                 pokemonDetailViewModel = pokemonDetailViewModel,
                 onClickBackButton = { navController.navigateUp() },
                 onClickEvolution = { pokemonName ->
-                    pokemonDetailViewModel.getPokemonSpeciesByName(pokemonName)
+                    coroutine.launch {
+                        pokemonDetailViewModel.getPokemonSpeciesById(englishName = pokemonName)
+                    }
                     navController.navigate(SearchScreen.PokemonEvolutionDetailScreen.route)
                 }
             )

--- a/app/src/main/java/com/example/pokebook/ui/screen/Navigation/BottomNavigationScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/Navigation/BottomNavigationScreen.kt
@@ -78,7 +78,7 @@ private fun NavigationHost(
         homeGraph(
             navController = navController,
             likeEntryViewModel = likeEntryViewModel,
-            pokemonDetailViewModel = homeDetailViewModel
+            pokemonDetailViewModel = homeDetailViewModel,
         )
         searchGraph(
             navController = navController,
@@ -131,6 +131,23 @@ fun NavGraphBuilder.homeGraph(
             PokemonDetailScreen(
                 likeEntryViewModel = likeEntryViewModel,
                 onClickBackButton = { navController.navigateUp() },
+                onClickEvolution = { pokemonName ->
+                    navController.navigate(HomeScreen.PokemonEvolutionDetailScreen.route)
+                    pokemonDetailViewModel.getPokemonSpeciesByName(pokemonName)
+                },
+                pokemonDetailViewModel = pokemonDetailViewModel
+            )
+        }
+        composable(
+            route = HomeScreen.PokemonEvolutionDetailScreen.route
+        ) {
+            PokemonDetailScreen(
+                likeEntryViewModel = likeEntryViewModel,
+                onClickBackButton = { navController.navigate(HomeScreen.PokemonListScreen.route) }, // TODO 一旦TOPにタブのTOPに戻すが、遷移前の詳細画面を保持してそこに戻す処理に変更予定
+                onClickEvolution = { pokemonName ->
+                    navController.navigate(HomeScreen.PokemonEvolutionDetailScreen.route)
+                    pokemonDetailViewModel.getPokemonSpeciesByName(pokemonName)
+                },
                 pokemonDetailViewModel = pokemonDetailViewModel
             )
         }
@@ -199,7 +216,22 @@ fun NavGraphBuilder.searchGraph(
             PokemonDetailScreen(
                 likeEntryViewModel = likeEntryViewModel,
                 pokemonDetailViewModel = pokemonDetailViewModel,
-                onClickBackButton = { navController.navigateUp() }
+                onClickBackButton = { navController.navigateUp() },
+                onClickEvolution = { pokemonName ->
+                    navController.navigate(SearchScreen.PokemonEvolutionDetailScreen.route)
+                    pokemonDetailViewModel.getPokemonSpeciesByName(pokemonName)
+                }
+            )
+        }
+        composable(route = SearchScreen.PokemonEvolutionDetailScreen.route) {
+            PokemonDetailScreen(
+                likeEntryViewModel = likeEntryViewModel,
+                pokemonDetailViewModel = pokemonDetailViewModel,
+                onClickBackButton = { navController.navigate(SearchScreen.PokemonListScreen.route) }, // TODO 一旦タブのtopに戻す
+                onClickEvolution = { pokemonName ->
+                    navController.navigate(SearchScreen.PokemonEvolutionDetailScreen.route)
+                    pokemonDetailViewModel.getPokemonSpeciesByName(pokemonName)
+                },
             )
         }
     }
@@ -235,7 +267,22 @@ fun NavGraphBuilder.likeGraph(
             PokemonDetailScreen(
                 likeEntryViewModel = likeEntryViewModel,
                 pokemonDetailViewModel = pokemonDetailViewModel,
-                onClickBackButton = { navController.navigateUp() }
+                onClickBackButton = { navController.navigateUp() },
+                onClickEvolution = { pokemonName ->
+                    navController.navigate(LikeScreen.PokemonEvolutionDetailScreen.route)
+                    pokemonDetailViewModel.getPokemonSpeciesByName(pokemonName)
+                },
+            )
+        }
+        composable(route = LikeScreen.PokemonEvolutionDetailScreen.route) {
+            PokemonDetailScreen(
+                likeEntryViewModel = likeEntryViewModel,
+                pokemonDetailViewModel = pokemonDetailViewModel,
+                onClickBackButton = { navController.navigate(LikeScreen.LikeListScreen.route) }, // TODO 一旦タブのtopに戻す
+                onClickEvolution = { pokemonName ->
+                    navController.navigate(LikeScreen.PokemonEvolutionDetailScreen.route)
+                    pokemonDetailViewModel.getPokemonSpeciesByName(pokemonName)
+                }
             )
         }
     }

--- a/app/src/main/java/com/example/pokebook/ui/screen/Navigation/ScreenRoutes.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/Navigation/ScreenRoutes.kt
@@ -6,6 +6,7 @@ package com.example.pokebook.ui.screen.Navigation
 sealed class HomeScreen(val route: String) {
     object PokemonListScreen : HomeScreen("home/pokemonListScreen")
     object PokemonDetailScreen : HomeScreen("home/pokemonDetailScreen")
+    object PokemonEvolutionDetailScreen:HomeScreen("home/pokemonEvolutionDetailScreen")
 }
 
 /**
@@ -17,6 +18,7 @@ sealed class SearchScreen(val route: String) {
     object PokemonNotFound : SearchScreen("search/pokemonNotFound")
     object PokemonDetailScreenByName : SearchScreen("search/pokemonDetailScreenByName")
     object PokemonDetailScreenByNumber : SearchScreen("search/pokemonDetailScreenByNumber")
+    object PokemonEvolutionDetailScreen:SearchScreen("search/pokemonEvolutionDetailScreen")
 }
 
 /**
@@ -24,7 +26,8 @@ sealed class SearchScreen(val route: String) {
  */
 sealed class LikeScreen(val route: String) {
     object LikeListScreen : LikeScreen("like/listScreen")
-    object LikeDetailScreen : LikeScreen("like/detailScreen")
+    object LikeDetailScreen : LikeScreen("like/pokemonDetailScreen")
+    object PokemonEvolutionDetailScreen:LikeScreen("like/pokemonEvolutionDetailScreen")
 }
 
 

--- a/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -52,6 +54,7 @@ import com.example.pokebook.model.Evolves
 import com.example.pokebook.model.EvolvesSpecies
 import com.example.pokebook.model.NextEvolves
 import com.example.pokebook.ui.AppViewModelProvider
+import com.example.pokebook.ui.screen.common.AutoSizeableText
 import com.example.pokebook.ui.viewModel.Detail.PokemonDetailScreenUiData
 import com.example.pokebook.ui.viewModel.Detail.PokemonDetailUiEvent
 import com.example.pokebook.ui.viewModel.Detail.PokemonDetailUiState
@@ -544,48 +547,6 @@ private fun EvolutionChainImage(
             contentDescription = null
         )
     }
-}
-
-/**
- * 文字サイズの自動調整
- */
-@Composable
-fun AutoSizeableText(
-    text: String,
-    color: Color,
-    maxTextSize: Int = 50,
-    minTextSize: Int = 40,
-    modifier: Modifier
-) {
-    var textSize by remember { mutableStateOf(maxTextSize) }
-    val checked = remember(text) { mutableMapOf<Int, Boolean?>() }
-    var overflow by remember { mutableStateOf(TextOverflow.Clip) }
-
-    androidx.compose.material.Text(
-        text = text,
-        color = color,
-        fontSize = textSize.sp,
-        maxLines = 1,
-        overflow = overflow,
-        modifier = modifier,
-        onTextLayout = {
-            if (it.hasVisualOverflow) {
-                checked[textSize] = true
-                if (textSize > minTextSize) {
-                    textSize -= 1
-                } else {
-                    overflow = TextOverflow.Ellipsis
-                }
-            } else {
-                checked[textSize] = false
-                if (textSize < maxTextSize) {
-                    if (checked[textSize + 1] == null) {
-                        textSize += 1
-                    }
-                }
-            }
-        }
-    )
 }
 
 /**

--- a/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
@@ -482,6 +482,38 @@ private fun EvolutionChain(
 }
 
 /**
+ * 進化系譜読み込み中画面
+ */
+@Composable
+private fun EvolutionChainLoading(modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier
+            .padding(horizontal = 20.dp)
+            .wrapContentHeight()
+            .fillMaxWidth(),
+        elevation = CardDefaults.cardElevation(4.dp)
+    ) {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = modifier
+                .padding(vertical = 20.dp)
+                .align(Alignment.CenterHorizontally)
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                CircularProgressIndicator()
+                Text(
+                    text = stringResource(R.string.evolution_chain_loading_text),
+                    modifier = modifier.padding(top = 5.dp)
+                )
+            }
+        }
+    }
+}
+
+/**
  * メニュー
  */
 @Composable

--- a/app/src/main/java/com/example/pokebook/ui/screen/TypeTag.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/TypeTag.kt
@@ -35,12 +35,12 @@ fun TypeTag(
         horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
-            .padding(top = 5.dp)
     ) {
         Text(
             text = stringResource(R.string.pokemon_type),
             fontSize = 20.sp,
-            modifier = modifier,
+            modifier = modifier
+                .padding(start = 10.dp),
             color = androidx.compose.material3.MaterialTheme.colorScheme.onSurfaceVariant
         )
         typeList.forEach { type ->

--- a/app/src/main/java/com/example/pokebook/ui/screen/common/common.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/common/common.kt
@@ -1,0 +1,56 @@
+package com.example.pokebook.ui.screen.common
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * 文字サイズの自動調整
+ */
+@Composable
+fun AutoSizeableText(
+    text: String,
+    color: Color,
+    maxTextSize: Int = 50,
+    minTextSize: Int = 40,
+    modifier: Modifier = Modifier
+) {
+    var textSize by remember { mutableStateOf(maxTextSize) }
+    val checked = remember(text) { mutableMapOf<Int, Boolean?>() }
+    var overflow by remember { mutableStateOf(TextOverflow.Clip) }
+
+    androidx.compose.material.Text(
+        text = text,
+        color = color,
+        fontSize = textSize.sp,
+        maxLines = 1,
+        overflow = overflow,
+        modifier = modifier,
+        onTextLayout = {
+            if (it.hasVisualOverflow) {
+                checked[textSize] = true
+                if (textSize > minTextSize) {
+                    textSize -= 1
+                } else {
+                    overflow = TextOverflow.Ellipsis
+                }
+            } else {
+                checked[textSize] = false
+                if (textSize < maxTextSize) {
+                    if (checked[textSize + 1] == null) {
+                        textSize += 1
+                    }
+                }
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailState.kt
@@ -1,12 +1,11 @@
 package com.example.pokebook.ui.viewModel.Detail
 
 import com.example.pokebook.model.EvolutionChain
-import com.example.pokebook.model.PokemonPersonalData
 import com.example.pokebook.ui.screen.ShowEvolution
 import java.util.UUID
 
 /**
- * 詳細画面の状態に関する情報
+ * 詳細画面の状態に関する状態
  */
 sealed class PokemonDetailUiState {
     object Loading : PokemonDetailUiState()
@@ -59,7 +58,7 @@ data class PokemonDetailScreenUiData(
     val isLike: Boolean = false,
     val speciesNumber: String = "",
     val evolutionChainNumber: String = "",
-    val resultEvolutionChain: EvolutionChain = EvolutionChain(null)
+    val displayEvolution: DisplayEvolution = DisplayEvolution()
 )
 
 /**
@@ -71,3 +70,22 @@ sealed class PokemonDetailUiEvent(
 ) {
     data class Error(val e: Throwable) : PokemonDetailUiEvent()
 }
+
+/**
+ * 進化系表示用クラス　新
+ */
+data class DisplayEvolution(
+    val basePokemonData: EvolutionPokemonDataState = EvolutionPokemonDataState(),
+    val nextPokemonData: List<NextPokemonData> = emptyList(),
+)
+
+data class NextPokemonData(
+    val nextPokemonData: EvolutionPokemonDataState = EvolutionPokemonDataState(),
+    var lastPokemonData: List<EvolutionPokemonDataState> = emptyList()
+)
+
+data class EvolutionPokemonDataState(
+    val japaneseName: String? = "",
+    val speciesNumber: String? = "",
+    val englishName: String? = "",
+)

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailState.kt
@@ -21,6 +21,15 @@ data class DetailUiCondition(
 )
 
 /**
+ * 進化系取得に関する状態
+ */
+sealed class EvolutionChainUiState {
+    object Loading : EvolutionChainUiState()
+    object InitialState : EvolutionChainUiState()
+    object Fetched : EvolutionChainUiState()
+}
+
+/**
  *　ID
  *　名前
  *　説明

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailState.kt
@@ -1,6 +1,8 @@
 package com.example.pokebook.ui.viewModel.Detail
 
+import com.example.pokebook.model.EvolutionChain
 import com.example.pokebook.model.PokemonPersonalData
+import com.example.pokebook.ui.screen.ShowEvolution
 import java.util.UUID
 
 /**
@@ -47,7 +49,8 @@ data class PokemonDetailScreenUiData(
     val weight: Double = 0.0,
     val isLike: Boolean = false,
     val speciesNumber: String = "",
-    val evolutionChainNumber: String = ""
+    val evolutionChainNumber: String = "",
+    val resultEvolutionChain: EvolutionChain = EvolutionChain(null)
 )
 
 /**

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailState.kt
@@ -46,7 +46,8 @@ data class PokemonDetailScreenUiData(
     val height: Double = 0.0,
     val weight: Double = 0.0,
     val isLike: Boolean = false,
-    val speciesNumber: String = ""
+    val speciesNumber: String = "",
+    val evolutionChainNumber: String = ""
 )
 
 /**

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailViewModel.kt
@@ -28,7 +28,6 @@ import kotlinx.coroutines.withContext
 
 class PokemonDetailViewModel(
     private val detailRepository: PokemonDetailRepository,
-    private val dataRepository: PokemonDataRepository,
     private val likesRepository: LikesRepository,
     private val pokemonDataRepository: PokemonDataRepository,
     private val evolutionChainRepository: EvolutionChainRepository

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailViewModel.kt
@@ -97,7 +97,8 @@ class PokemonDetailViewModel(
                             imageUri = roomResult.imageUrl ?: "",
                             type = roomResult.type ?: emptyList(),
                             genus = roomResult.genus ?: "",
-                            speciesNumber = roomResult.speciesNumber ?: ""
+                            speciesNumber = roomResult.speciesNumber ?: "",
+                            evolutionChainNumber = roomResult.evolutionChainNumber ?: ""
                         )
                     }
                 }
@@ -118,7 +119,8 @@ class PokemonDetailViewModel(
                                 imageUrl = conditionState.value.imageUri,
                                 speciesNumber = conditionState.value.speciesNumber,
                                 type = conditionState.value.type,
-                                genus = conditionState.value.genus
+                                genus = conditionState.value.genus,
+                                evolutionChainNumber = conditionState.value.evolutionChainNumber
                             )
                         )
                     )
@@ -136,7 +138,8 @@ class PokemonDetailViewModel(
                         imageUrl = conditionState.value.imageUri,
                         speciesNumber = conditionState.value.speciesNumber,
                         type = conditionState.value.type,
-                        genus = conditionState.value.genus
+                        genus = conditionState.value.genus,
+                        evolutionChainNumber = conditionState.value.evolutionChainNumber
                     )
                 }
             }
@@ -189,7 +192,8 @@ class PokemonDetailViewModel(
                         flavorTextEntries.language.name == "ja"
                     }?.flavorText ?: "日本語の説明が存在しません...",
                     imageUri = apiResult.sprites.other.officialArtwork.imgUrl ?: "",
-                    speciesNumber = apiResult.id.toString()
+                    speciesNumber = apiResult.id.toString(),
+                    evolutionChainNumber = Uri.parse(species.evolutionChain.url).lastPathSegment ?: ""
                 )
             }
             // hp attack defense speed
@@ -252,6 +256,21 @@ class PokemonDetailViewModel(
                 }
             }
 
+//            // evolutionChainNumberがない場合
+//            if (roomResult.evolutionChainNumber.isNullOrEmpty()) {
+//                _conditionState.update { currentState ->
+//                    currentState.copy(
+//                        evolutionChainNumber = Uri.parse(species.evolutionChain).lastPathSegment ?: ""
+//                    )
+//                }
+//            } else {
+//                _conditionState.update { currentState ->
+//                    currentState.copy(
+//                        evolutionChainNumber = roomResult.evolutionChainNumber
+//                    )
+//                }
+//            }
+
             // DB情報を使ってconditionStateを更新
             _conditionState.update { currentState ->
                 currentState.copy(
@@ -273,7 +292,8 @@ class PokemonDetailViewModel(
                     ?: "該当する分類が存在しません...",
                 type = apiResult.types.map { types -> types.type.name },
                 height = apiResult.height / 10.0,
-                weight = apiResult.weight / 10.0
+                weight = apiResult.weight / 10.0,
+                evolutionChainNumber = Uri.parse(species.evolutionChain.url).lastPathSegment ?: ""
             )
         }
     }

--- a/app/src/main/res/drawable/baseline_hide_image_24.xml
+++ b/app/src/main/res/drawable/baseline_hide_image_24.xml
@@ -1,0 +1,6 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M21,5c0,-1.1 -0.9,-2 -2,-2H5.83L21,18.17V5z"/>
+    <path android:fillColor="@android:color/white" android:pathData="M2.81,2.81L1.39,4.22L3,5.83V19c0,1.1 0.9,2 2,2h13.17l1.61,1.61l1.41,-1.41L2.81,2.81zM6,17l3,-4l2.25,3l0.82,-1.1l2.1,2.1H6z"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,4 +53,5 @@
     <string name="like_header_title">お気に入りのポケモン一覧</string>
     <string name="search_by_name_error_text">結果を取得できませんでした。\n検索ワードがカタカナで正しく入力されていることを\n確認して下さい。</string>
     <string name="search_by_id_error_text">結果を取得できませんでした。\n検索IDが正しいことを確認して下さい。</string>
+    <string name="nextPokemonImageUrl">https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/%s.png</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,4 +54,5 @@
     <string name="search_by_name_error_text">結果を取得できませんでした。\n検索ワードがカタカナで正しく入力されていることを\n確認して下さい。</string>
     <string name="search_by_id_error_text">結果を取得できませんでした。\n検索IDが正しいことを確認して下さい。</string>
     <string name="nextPokemonImageUrl">https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/%s.png</string>
+    <string name="evolution_chain_loading_text">読み込み中...</string>
 </resources>


### PR DESCRIPTION
## 対応内容

* 進化系譜表示用Conposableの作成
* 進化系譜取得用のAPI周りの処理追加
* 進化系譜取得中のLoadingアイコンとStateを追加
* 名前検索用のAPI周りの処置追加と、既存処理の修正
* 一部不要な処理の削除



## スクリーンショット

| before | after | after |
|--------|-------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/31569e54-eddd-4b76-bb9b-2c4544fd31b8" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/7efdde62-376d-4b8b-9c41-1ae02078b821" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/4221edc6-7c41-4796-be9c-6940603c6db6" width="200px"/>|


