### PR TITLE
ある分岐の時に身長体重情報が更新されない事象を修正＋不要な処理の削除

### DIFF
--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailViewModel.kt
@@ -78,16 +78,19 @@ class PokemonDetailViewModel(
                 } else {
                     pokemonDataRepository.searchPokemonByKeyword(englishName)
                 }
-                // DBにデータが存在していなければAPIを叩く
-                if (roomResult == null) {
-                    val result = if (englishName.isEmpty()) {
-                        getApiPokemonData(
-                            pokemonNumber = pokemonNumber,
-                            speciesNumber = speciesNumber
-                        )
-                    } else {
-                        getApiPokemonData(englishName = englishName)
-                    }
+
+                // APIからポケモン情報取得
+                val result = if (englishName.isEmpty()) {
+                    getApiPokemonData(
+                        pokemonNumber = pokemonNumber,
+                        speciesNumber = speciesNumber
+                    )
+                } else {
+                    getApiPokemonData(englishName = englishName)
+                }
+
+                // DBにデータが存在していなければAPIの情報で更新
+                if (roomResult == null || roomResult.description.isNullOrEmpty()) {
                     // 必要情報を取得してconditionStateを更新
                     updateCondition(
                         apiResult = result.personalData,
@@ -98,28 +101,7 @@ class PokemonDetailViewModel(
                         roomResult = roomResult,
                         pokemonNumber = result.species.id
                     )
-
                     // DBにdescriptionがない場合
-                } else if (roomResult.description.isNullOrEmpty()) {
-                    val result = if (englishName.isEmpty()) {
-                        getApiPokemonData(
-                            pokemonNumber = pokemonNumber,
-                            speciesNumber = speciesNumber
-                        )
-                    } else {
-                        getApiPokemonData(englishName = englishName)
-                    }
-                    // 必要情報を取得してconditionStateを更新
-                    updateCondition(
-                        roomResult = roomResult,
-                        apiResult = result.personalData,
-                        species = result.species
-                    )
-                    // pokemonNumberに該当するDBの情報を更新
-                    saveDataBase(
-                        roomResult = roomResult,
-                        pokemonNumber = result.species.id
-                    )
                 } else {
                     //conditionStateを更新
                     _conditionState.update { currentState ->
@@ -135,6 +117,8 @@ class PokemonDetailViewModel(
                             imageUri = roomResult.imageUrl ?: "",
                             type = roomResult.type ?: emptyList(),
                             genus = roomResult.genus ?: "",
+                            height = result.personalData.height / 10.0,
+                            weight = result.personalData.weight / 10.0,
                             speciesNumber = roomResult.speciesNumber ?: "",
                             evolutionChainNumber = roomResult.evolutionChainNumber ?: ""
                         )


### PR DESCRIPTION

## 対応内容

* roomにデータが存在しているポケモンの詳細画面を開く際、身長体重のデータ更新が漏れていたため追加
* それに伴い不要な処理の削除と処理の共通化



## スクリーンショット

| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/e1354c04-59cd-47ce-9e62-934917f6a73e" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/38fc0e30-c0b9-4b16-b8eb-b4abe56986e6" width="200px"/>|

