### PR TITLE
詳細画面から任意の進化系ポケモン詳細画面へ遷移した際のBackボタンの挙動を修正

### DIFF
--- a/app/src/main/java/com/example/pokebook/ui/screen/Navigation/BottomNavigationScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/Navigation/BottomNavigationScreen.kt
@@ -133,6 +133,7 @@ fun NavGraphBuilder.homeGraph(
                 onClickBackButton = { navController.navigateUp() },
                 onClickEvolution = { pokemonName ->
                     pokemonDetailViewModel.getPokemonSpeciesById(englishName = pokemonName)
+                    pokemonDetailViewModel.saveConditionState()
                     navController.navigate(HomeScreen.PokemonEvolutionDetailScreen.route)
                 },
                 pokemonDetailViewModel = pokemonDetailViewModel
@@ -141,9 +142,13 @@ fun NavGraphBuilder.homeGraph(
         composable(route = HomeScreen.PokemonEvolutionDetailScreen.route) {
             PokemonDetailScreen(
                 likeEntryViewModel = likeEntryViewModel,
-                onClickBackButton = { navController.navigate(HomeScreen.PokemonListScreen.route) }, // TODO 一旦TOPにタブのTOPに戻すが、遷移前の詳細画面を保持してそこに戻す処理に変更予定
+                onClickBackButton = {
+                    pokemonDetailViewModel.onClickBackButton()
+                    navController.navigateUp()
+                },
                 onClickEvolution = { pokemonName ->
                     pokemonDetailViewModel.getPokemonSpeciesById(englishName = pokemonName)
+                    pokemonDetailViewModel.saveConditionState()
                     navController.navigate(HomeScreen.PokemonEvolutionDetailScreen.route)
                 },
                 pokemonDetailViewModel = pokemonDetailViewModel
@@ -210,6 +215,7 @@ fun NavGraphBuilder.searchGraph(
                 onClickBackButton = { navController.navigateUp() },
                 onClickEvolution = { pokemonName ->
                     pokemonDetailViewModel.getPokemonSpeciesById(englishName = pokemonName)
+                    pokemonDetailViewModel.saveConditionState()
                     navController.navigate(SearchScreen.PokemonEvolutionDetailScreen.route)
                 }
             )
@@ -221,6 +227,7 @@ fun NavGraphBuilder.searchGraph(
                 onClickBackButton = { navController.navigateUp() },
                 onClickEvolution = { pokemonName ->
                     pokemonDetailViewModel.getPokemonSpeciesById(englishName = pokemonName)
+                    pokemonDetailViewModel.saveConditionState()
                     navController.navigate(SearchScreen.PokemonEvolutionDetailScreen.route)
                 }
             )
@@ -229,9 +236,13 @@ fun NavGraphBuilder.searchGraph(
             PokemonDetailScreen(
                 likeEntryViewModel = likeEntryViewModel,
                 pokemonDetailViewModel = pokemonDetailViewModel,
-                onClickBackButton = { navController.navigate(SearchScreen.SearchTopScreen.route) }, // TODO 一旦タブのtopに戻す
+                onClickBackButton = {
+                    pokemonDetailViewModel.onClickBackButton()
+                    navController.navigateUp()
+                },
                 onClickEvolution = { pokemonName ->
                     pokemonDetailViewModel.getPokemonSpeciesById(englishName = pokemonName)
+                    pokemonDetailViewModel.saveConditionState()
                     navController.navigate(SearchScreen.PokemonEvolutionDetailScreen.route)
                 },
             )
@@ -272,6 +283,7 @@ fun NavGraphBuilder.likeGraph(
                 onClickBackButton = { navController.navigateUp() },
                 onClickEvolution = { pokemonName ->
                     pokemonDetailViewModel.getPokemonSpeciesById(englishName = pokemonName)
+                    pokemonDetailViewModel.saveConditionState()
                     navController.navigate(LikeScreen.PokemonEvolutionDetailScreen.route)
                 },
             )
@@ -280,9 +292,13 @@ fun NavGraphBuilder.likeGraph(
             PokemonDetailScreen(
                 likeEntryViewModel = likeEntryViewModel,
                 pokemonDetailViewModel = pokemonDetailViewModel,
-                onClickBackButton = { navController.navigate(LikeScreen.LikeListScreen.route) }, // TODO 一旦タブのtopに戻す
+                onClickBackButton = {
+                    pokemonDetailViewModel.onClickBackButton()
+                    navController.navigateUp()
+                },
                 onClickEvolution = { pokemonName ->
                     pokemonDetailViewModel.getPokemonSpeciesById(englishName = pokemonName)
+                    pokemonDetailViewModel.saveConditionState()
                     navController.navigate(LikeScreen.PokemonEvolutionDetailScreen.route)
                 }
             )

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailState.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailState.kt
@@ -62,6 +62,29 @@ data class PokemonDetailScreenUiData(
 )
 
 /**
+ * 直前の詳細画面に関するデータを格納
+ */
+data class PreviousPokemonDetailScreenUiData(
+    val pokemonNumber: Int = 0,
+    val englishName: String = "",
+    val japaneseName: String = "",
+    val description: String = "",
+    val genus: String = "",
+    val type: List<String> = emptyList(),
+    val hp: Int = 0,
+    val attack: Int = 0,
+    val defense: Int = 0,
+    val speed: Int = 0,
+    val imageUri: String = "",
+    val height: Double = 0.0,
+    val weight: Double = 0.0,
+    val isLike: Boolean = false,
+    val speciesNumber: String = "",
+    val evolutionChainNumber: String = "",
+    val displayEvolution: DisplayEvolution = DisplayEvolution()
+)
+
+/**
  * エラー表示に関する情報
  */
 sealed class PokemonDetailUiEvent(

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailViewModel.kt
@@ -42,6 +42,8 @@ class PokemonDetailViewModel(
         MutableStateFlow(PokemonDetailScreenUiData())
     val conditionState = _conditionState.asStateFlow()
 
+    private var conditionStatePrevious = PreviousPokemonDetailScreenUiData()
+
     private var _pokemonListUiDataConditionState: MutableStateFlow<PokemonListUiData> =
         MutableStateFlow(PokemonListUiData())
 
@@ -567,6 +569,59 @@ class PokemonDetailViewModel(
             }
         }.onFailure {
             Log.d("error", "error：$it")
+        }
+    }
+
+    /**
+     * 別の詳細画面遷移前に詳細画面情報を格納
+     */
+    fun saveConditionState() {
+        conditionStatePrevious = PreviousPokemonDetailScreenUiData(
+            pokemonNumber = conditionState.value.pokemonNumber,
+            englishName = conditionState.value.englishName,
+            japaneseName = conditionState.value.japaneseName,
+            description = conditionState.value.description,
+            genus = conditionState.value.genus,
+            type = conditionState.value.type,
+            hp = conditionState.value.hp,
+            attack = conditionState.value.attack,
+            defense = conditionState.value.defense,
+            speed = conditionState.value.speed,
+            imageUri = conditionState.value.imageUri,
+            height = conditionState.value.height,
+            weight = conditionState.value.weight,
+            isLike = conditionState.value.isLike,
+            speciesNumber = conditionState.value.speciesNumber,
+            evolutionChainNumber = conditionState.value.evolutionChainNumber,
+            displayEvolution = conditionState.value.displayEvolution
+        )
+    }
+
+
+    /**
+     * 別の詳細画面から戻る時に表示する詳細画面
+     */
+    fun onClickBackButton() {
+        _conditionState.update { currentState ->
+            currentState.copy(
+                pokemonNumber = conditionStatePrevious.pokemonNumber,
+                englishName = conditionStatePrevious.englishName,
+                japaneseName = conditionStatePrevious.japaneseName,
+                description = conditionStatePrevious.description,
+                genus = conditionStatePrevious.genus,
+                type = conditionStatePrevious.type,
+                hp = conditionStatePrevious.hp,
+                attack = conditionStatePrevious.attack,
+                defense = conditionStatePrevious.defense,
+                speed = conditionStatePrevious.speed,
+                imageUri = conditionStatePrevious.imageUri,
+                height = conditionStatePrevious.height,
+                weight = conditionStatePrevious.weight,
+                isLike = conditionStatePrevious.isLike,
+                speciesNumber = conditionStatePrevious.speciesNumber,
+                evolutionChainNumber = conditionStatePrevious.evolutionChainNumber,
+                displayEvolution = conditionStatePrevious.displayEvolution
+            )
         }
     }
 }


### PR DESCRIPTION
## 対応内容

* 元々はタブのTOP画面に戻ってしまっていたが、直前の詳細画面へ戻れるよう修正
* 詳細画面から別の詳細画面へ遷移する直前に、Stateを保持しておく仕組みを追加




## スクリーンショット

| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/352b12bf-5242-425c-b0ee-31a70099c401" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/ccf9bda3-6b94-4606-90e5-bf3de4236b2e" width="200px"/>|

