### PR TITLE
DBに存在しないポケモンをお気に入りに入れるとお気に入り一覧から詳細遷移できない不具合を修正

### DIFF
--- a/app/src/main/java/com/example/pokebook/ui/screen/Navigation/BottomNavigationScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/Navigation/BottomNavigationScreen.kt
@@ -266,11 +266,11 @@ fun NavGraphBuilder.likeGraph(
             likeEntryViewModel.getAllList()
             LikeEntryScreen(
                 onClickCard = { speciesNumber, pokemonNumber ->
-                    navController.navigate(LikeScreen.LikeDetailScreen.route)
                     pokemonDetailViewModel.getPokemonSpeciesById(
                         pokemonNumber = pokemonNumber,
                         speciesNumber = speciesNumber
                     )
+                    navController.navigate(LikeScreen.LikeDetailScreen.route)
                 },
                 onClickBackButton = { navController.navigateUp() },
                 likeEntryViewModel = likeEntryViewModel

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailViewModel.kt
@@ -99,7 +99,7 @@ class PokemonDetailViewModel(
                     // 新規でDBに保存
                     saveDataBase(
                         roomResult = roomResult,
-                        pokemonNumber = result.species.id
+                        pokemonNumber = pokemonNumber
                     )
                     // DBにdescriptionがない場合
                 } else {
@@ -180,7 +180,7 @@ class PokemonDetailViewModel(
                         flavorTextEntries.language.name == "ja"
                     }?.flavorText ?: "日本語の説明が存在しません...",
                     imageUri = apiResult.sprites.other.officialArtwork.imgUrl ?: "",
-                    speciesNumber = apiResult.id.toString(),
+                    speciesNumber = Uri.parse(apiResult.species.url)?.lastPathSegment ?: "",
                     evolutionChainNumber = Uri.parse(species.evolutionChain.url).lastPathSegment
                         ?: ""
                 )


### PR DESCRIPTION

## 対応内容

* DBにデータが存在しないポケモンのspeciesNumberが、ポケモンナンバーを取得してしまっていた
* DBにデータが存在しないポケモンのDB保存じのポケモンナンバーがspeciesNumberになってしまっていた


## スクリーンショット

| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/70c2f8bd-fd51-4438-8c78-f389256b428a" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/f4ab95d7-2a7d-4ace-b7e8-343975a7354a" width="200px"/>|
