### PR TITLE
詳細画面で画像取得が遅れた際にLoadingアイコンが出るように修正

### DIFF
--- a/app/src/main/java/com/example/pokebook/ui/screen/Navigation/BottomNavigationScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/Navigation/BottomNavigationScreen.kt
@@ -132,8 +132,9 @@ fun NavGraphBuilder.homeGraph(
                 likeEntryViewModel = likeEntryViewModel,
                 onClickBackButton = { navController.navigateUp() },
                 onClickEvolution = { pokemonName ->
-                    pokemonDetailViewModel.getPokemonSpeciesById(englishName = pokemonName)
                     pokemonDetailViewModel.saveConditionState()
+                    pokemonDetailViewModel.initState()
+                    pokemonDetailViewModel.getPokemonSpeciesById(englishName = pokemonName)
                     navController.navigate(HomeScreen.PokemonEvolutionDetailScreen.route)
                 },
                 pokemonDetailViewModel = pokemonDetailViewModel
@@ -147,8 +148,9 @@ fun NavGraphBuilder.homeGraph(
                     navController.navigateUp()
                 },
                 onClickEvolution = { pokemonName ->
-                    pokemonDetailViewModel.getPokemonSpeciesById(englishName = pokemonName)
                     pokemonDetailViewModel.saveConditionState()
+                    pokemonDetailViewModel.initState()
+                    pokemonDetailViewModel.getPokemonSpeciesById(englishName = pokemonName)
                     navController.navigate(HomeScreen.PokemonEvolutionDetailScreen.route)
                 },
                 pokemonDetailViewModel = pokemonDetailViewModel
@@ -214,8 +216,9 @@ fun NavGraphBuilder.searchGraph(
                 pokemonDetailViewModel = pokemonDetailViewModel,
                 onClickBackButton = { navController.navigateUp() },
                 onClickEvolution = { pokemonName ->
-                    pokemonDetailViewModel.getPokemonSpeciesById(englishName = pokemonName)
                     pokemonDetailViewModel.saveConditionState()
+                    pokemonDetailViewModel.initState()
+                    pokemonDetailViewModel.getPokemonSpeciesById(englishName = pokemonName)
                     navController.navigate(SearchScreen.PokemonEvolutionDetailScreen.route)
                 }
             )
@@ -226,8 +229,9 @@ fun NavGraphBuilder.searchGraph(
                 pokemonDetailViewModel = pokemonDetailViewModel,
                 onClickBackButton = { navController.navigateUp() },
                 onClickEvolution = { pokemonName ->
-                    pokemonDetailViewModel.getPokemonSpeciesById(englishName = pokemonName)
                     pokemonDetailViewModel.saveConditionState()
+                    pokemonDetailViewModel.initState()
+                    pokemonDetailViewModel.getPokemonSpeciesById(englishName = pokemonName)
                     navController.navigate(SearchScreen.PokemonEvolutionDetailScreen.route)
                 }
             )
@@ -241,10 +245,11 @@ fun NavGraphBuilder.searchGraph(
                     navController.navigateUp()
                 },
                 onClickEvolution = { pokemonName ->
-                    pokemonDetailViewModel.getPokemonSpeciesById(englishName = pokemonName)
                     pokemonDetailViewModel.saveConditionState()
+                    pokemonDetailViewModel.initState()
+                    pokemonDetailViewModel.getPokemonSpeciesById(englishName = pokemonName)
                     navController.navigate(SearchScreen.PokemonEvolutionDetailScreen.route)
-                },
+                }
             )
         }
     }
@@ -282,8 +287,9 @@ fun NavGraphBuilder.likeGraph(
                 pokemonDetailViewModel = pokemonDetailViewModel,
                 onClickBackButton = { navController.navigateUp() },
                 onClickEvolution = { pokemonName ->
-                    pokemonDetailViewModel.getPokemonSpeciesById(englishName = pokemonName)
                     pokemonDetailViewModel.saveConditionState()
+                    pokemonDetailViewModel.initState()
+                    pokemonDetailViewModel.getPokemonSpeciesById(englishName = pokemonName)
                     navController.navigate(LikeScreen.PokemonEvolutionDetailScreen.route)
                 },
             )
@@ -297,8 +303,9 @@ fun NavGraphBuilder.likeGraph(
                     navController.navigateUp()
                 },
                 onClickEvolution = { pokemonName ->
-                    pokemonDetailViewModel.getPokemonSpeciesById(englishName = pokemonName)
                     pokemonDetailViewModel.saveConditionState()
+                    pokemonDetailViewModel.initState()
+                    pokemonDetailViewModel.getPokemonSpeciesById(englishName = pokemonName)
                     navController.navigate(LikeScreen.PokemonEvolutionDetailScreen.route)
                 }
             )

--- a/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
+++ b/app/src/main/java/com/example/pokebook/ui/screen/PokemonDetailScreen.kt
@@ -2,6 +2,7 @@ package com.example.pokebook.ui.screen
 
 import android.annotation.SuppressLint
 import android.net.Uri
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -30,19 +31,27 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Alignment.Companion.BottomCenter
+import androidx.compose.ui.Alignment.Companion.Center
+import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
+import coil.compose.SubcomposeAsyncImage
+import coil.request.DefaultRequestOptions
 import coil.request.ImageRequest
 import com.example.pokebook.R
 import com.example.pokebook.model.Chain
@@ -327,7 +336,7 @@ private fun TitleImage(
                         updateIsLike.invoke(!pokemon.isLike, pokemon.pokemonNumber)
                     }
             )
-            AsyncImage(
+            SubcomposeAsyncImage(
                 model = ImageRequest.Builder(context = LocalContext.current)
                     .data(pokemon.imageUri)
                     .crossfade(true)
@@ -336,7 +345,15 @@ private fun TitleImage(
                     .fillMaxWidth()
                     .height(250.dp),
                 contentScale = ContentScale.Fit,
-                contentDescription = null
+                contentDescription = null,
+                loading = {
+                    Box(contentAlignment = Center) {
+                        CircularProgressIndicator(
+                            modifier = Modifier
+                                .size(50.dp)
+                        )
+                    }
+                }
             )
         }
     }

--- a/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailViewModel.kt
+++ b/app/src/main/java/com/example/pokebook/ui/viewModel/Detail/PokemonDetailViewModel.kt
@@ -16,6 +16,7 @@ import com.example.pokebook.ui.screen.ShowEvolution
 import com.example.pokebook.ui.screen.convertToShowEvolution
 import com.example.pokebook.ui.viewModel.Home.PokemonListUiData
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -623,6 +624,13 @@ class PokemonDetailViewModel(
                 displayEvolution = conditionStatePrevious.displayEvolution
             )
         }
+    }
+
+    /**
+     * 初期化
+     */
+    fun initState() = viewModelScope.launch {
+        _uiState.emit(PokemonDetailUiState.InitialState)
     }
 }
 


### PR DESCRIPTION

## 対応内容

* SubcomposeAsyncImageを使って画像取得中はLoadingアイコンを表示するよう修正
* 進化系アイコン選択時、詳細画面のStateを初期化するよう修正



## スクリーンショット

| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/f0668294-f327-48ea-959c-e4cab0f6caea" width="200px"/>|<img src="https://github.com/yanPWA/PokeBook/assets/82929509/3cf81e08-4e6e-45a3-9b5b-0d6d4e5e0d4c" width="200px"/>|

